### PR TITLE
新規アンケート作成のタイトルの背景

### DIFF
--- a/client/src/style/colors.scss
+++ b/client/src/style/colors.scss
@@ -66,8 +66,11 @@ summary {
 }
 
 // editing background
-.is-editing {
-  background-color: $base-darkbrown;
+.details-child,
+#edit-button {
+  &.is-editing {
+    background-color: $base-darkbrown;
+  }
 }
 
 // card


### PR DESCRIPTION
 - before
![image](https://user-images.githubusercontent.com/49056869/64693878-43ab5280-d4d3-11e9-8ff1-22a673f5fb9e.png)

 - after
![image](https://user-images.githubusercontent.com/49056869/64693907-54f45f00-d4d3-11e9-86e0-f7177beb2f52.png)

微妙にある四隅の茶色い部分を白くしました
`.is-editing`の使われている場所が把握しきれていないのでもしかしたら別のところが茶色くなくなってるかもしれません…

よろしくお願いします