### PR TITLE
各ページごとにタイトルを表示するように

### DIFF
--- a/client/src/main.js
+++ b/client/src/main.js
@@ -7,6 +7,19 @@ import store from './store'
 
 Vue.config.productionTip = false
 
+Vue.mixin({
+  watch: {
+    title(val) {
+      document.title = `${val} | anke-to`
+    }
+  },
+  mounted() {
+    if (this.title) {
+      document.title = `${this.title} | anke-to`
+    }
+  }
+})
+
 /* eslint-disable no-new */
 new Vue({
   el: '#app',

--- a/client/src/pages/Administrates.vue
+++ b/client/src/pages/Administrates.vue
@@ -55,6 +55,7 @@ export default {
   props: {},
   data() {
     return {
+      title: '管理者になっているアンケート一覧',
       questionnaires: [],
       headers: [
         'Title',

--- a/client/src/pages/Explorer.vue
+++ b/client/src/pages/Explorer.vue
@@ -138,6 +138,7 @@ export default {
   props: {},
   data() {
     return {
+      title: 'アンケート一覧',
       questionnaires: [],
       headers: ['', '回答期限', '更新日時', '作成日時', '結果'],
       sortOrders: [

--- a/client/src/pages/NotFound.vue
+++ b/client/src/pages/NotFound.vue
@@ -6,6 +6,11 @@
 
 <script>
 export default {
-  name: 'NotFound'
+  name: 'NotFound',
+  data() {
+    return {
+      title: 'ページが見つかりませんでした'
+    }
+  }
 }
 </script>

--- a/client/src/pages/QuestionnaireDetails.vue
+++ b/client/src/pages/QuestionnaireDetails.vue
@@ -180,7 +180,7 @@ export default {
       }
     },
     title() {
-      return this.information.title
+      return this.information.title || '新規アンケート作成'
     },
     informationProps() {
       return {

--- a/client/src/pages/ResponseDetails.vue
+++ b/client/src/pages/ResponseDetails.vue
@@ -180,6 +180,9 @@ export default {
         }
       }
       return ret
+    },
+    title() {
+      return this.information.title
     }
   },
   watch: {

--- a/client/src/pages/Responses.vue
+++ b/client/src/pages/Responses.vue
@@ -61,6 +61,7 @@ export default {
   props: {},
   data() {
     return {
+      title: '回答一覧',
       responses: [],
       headers: ['', '回答期限', '回答日時', '更新日時', '回答']
     }

--- a/client/src/pages/Targeted.vue
+++ b/client/src/pages/Targeted.vue
@@ -56,6 +56,7 @@ export default {
   props: {},
   data() {
     return {
+      title: '回答対象のアンケート一覧',
       questionnaires: [],
       headers: [
         'Title',


### PR DESCRIPTION
各ページごとにタブのタイトルを変更するようにしました。
アンケートのページはアンケート名、それ以外は固定のタイトルを表示するようにしています。

![image](https://user-images.githubusercontent.com/19851537/67551705-7b4d2180-f744-11e9-81ed-0f688b14993a.png)

![image](https://user-images.githubusercontent.com/19851537/67551725-843df300-f744-11e9-8a34-57241cb8792d.png)
