### PR TITLE
長文の質問を作成できるように close #17

### DIFF
--- a/client/src/bin/common.js
+++ b/client/src/bin/common.js
@@ -37,6 +37,7 @@ export default {
     }
     switch (data.question_type) {
       case 'Text':
+      case 'TextArea':
       case 'Number':
         question.responseBody = ''
         break
@@ -90,6 +91,7 @@ export default {
     let question = Object.assign({}, questionData)
     switch (question.type) {
       case 'Text':
+      case 'TextArea':
         question.responseBody = responseData.response
         break
       case 'Number':
@@ -117,6 +119,11 @@ export default {
     Text: {
       type: 'Text',
       label: 'テキスト',
+      component: 'short-answer'
+    },
+    TextArea: {
+      type: 'TextArea',
+      label: 'テキスト（長文）',
       component: 'short-answer'
     },
     Number: {

--- a/client/src/components/Questions/ShortAnswer.vue
+++ b/client/src/components/Questions/ShortAnswer.vue
@@ -16,7 +16,7 @@
     <p
       v-if="!editMode && typeof content.responseBody !== 'undefined'"
       class="has-underline"
-      :class="{ 'multi-line': content.type === 'TextArea'}"
+      :class="{ 'multi-line': content.type === 'TextArea' }"
     >
       {{ content.responseBody }}
     </p>

--- a/client/src/components/Questions/ShortAnswer.vue
+++ b/client/src/components/Questions/ShortAnswer.vue
@@ -16,6 +16,7 @@
     <p
       v-if="!editMode && typeof content.responseBody !== 'undefined'"
       class="has-underline"
+      :class="{ 'multi-line': content.type === 'TextArea'}"
     >
       {{ content.responseBody }}
     </p>
@@ -35,6 +36,13 @@
       class="input has-underline"
       placeholder="0"
     />
+    <textarea
+      v-if="editMode === 'response' && content.type === 'TextArea'"
+      v-model="content.responseBody"
+      class="input has-underline"
+      placeholder="回答"
+      rows="5"
+    ></textarea>
   </div>
 </template>
 
@@ -63,7 +71,7 @@ export default {
       return this.contentProps
     },
     responsePlaceholder() {
-      if (this.content.type === 'Text') {
+      if (this.content.type === 'Text' || this.content.type === 'TextArea') {
         return '回答 (テキスト)'
       } else if (this.content.type === 'Number') {
         return '回答 (数値)'
@@ -84,5 +92,14 @@ export default {
   &.has-underline {
     border-bottom: $base-brown dotted 0.5px;
   }
+}
+
+.multi-line {
+  white-space: pre-line;
+  word-break: break-all;
+}
+
+textarea {
+  height: 10em;
 }
 </style>

--- a/client/src/components/Results/Spreadsheet.vue
+++ b/client/src/components/Results/Spreadsheet.vue
@@ -244,6 +244,7 @@ td {
   vertical-align: middle;
   font-size: 0.9em;
   min-width: 10em;
+  word-break: break-all;
 }
 
 th.active {

--- a/client/src/pages/ResponseDetails.vue
+++ b/client/src/pages/ResponseDetails.vue
@@ -357,6 +357,7 @@ export default {
             })
             break
           case 'Text':
+          case 'TextArea':
           case 'Number':
             body.option_response = []
             body.response = String(question.responseBody)
@@ -374,6 +375,7 @@ export default {
       let hasSelectedOption = false
       switch (question.type) {
         case 'Text':
+        case 'TextArea':
         case 'Number':
           return (
             typeof question.responseBody !== 'undefined' &&


### PR DESCRIPTION
`question_type: TextArea`な質問を作成できるようにしました。
実際の表示は以下の通りです。

![image](https://user-images.githubusercontent.com/19851537/67561751-61b5d500-f758-11e9-84e0-31f564926e96.png)

![image](https://user-images.githubusercontent.com/19851537/67561790-709c8780-f758-11e9-89d5-c1a4a219efde.png)

![image](https://user-images.githubusercontent.com/19851537/67561854-91fd7380-f758-11e9-93ac-19cba95b4821.png)

![image](https://user-images.githubusercontent.com/19851537/67561876-99248180-f758-11e9-83d9-c074b6a85efb.png)
