### PR TITLE
/questionnaires/:idの認証設定

### DIFF
--- a/router/middleware.go
+++ b/router/middleware.go
@@ -1,0 +1,90 @@
+package router
+
+import (
+	"errors"
+	"fmt"
+	"net/http"
+	"strconv"
+
+	"github.com/labstack/echo"
+	"github.com/traPtitech/anke-to/model"
+)
+
+const (
+	userIDKey          = "userID"
+	questionnaireIDKey = "questionnaireID"
+)
+
+/* 消せないアンケートの発生を防ぐための管理者
+暫定的にハードコーディングで対応*/
+var adminUserIDs = []string{"temma", "sappi_red", "ryoha", "mazrean", "YumizSui", "pure_white_404"}
+
+// UserAuthenticate traPのメンバーかの認証
+func UserAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		userID := model.GetUserID(c)
+		// トークンを持たないユーザはアクセスできない
+		if userID == "-" {
+			return echo.NewHTTPError(http.StatusUnauthorized, "You are not logged in")
+		}
+
+		c.Set(userIDKey, userID)
+
+		return next(c)
+	}
+}
+
+// QuestionnaireAdministratorAuthenticate アンケートの管理者かどうかの認証
+func QuestionnaireAdministratorAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		userID, err := getUserID(c)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get userID: %w", err))
+		}
+
+		strQuestionnaireID := c.Param("questionnaireID")
+		questionnaireID, err := strconv.Atoi(strQuestionnaireID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid questionnaireID:%s(error: %w)", strQuestionnaireID, err))
+		}
+
+		for _, adminID := range adminUserIDs {
+			if userID == adminID {
+				c.Set(questionnaireIDKey, questionnaireID)
+
+				return next(c)
+			}
+		}
+		isAdmin, err := model.CheckAdmin(userID, questionnaireID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if you are administrator: %w", err))
+		}
+		if !isAdmin {
+			return c.String(http.StatusForbidden, "You are not a administrator of this questionnaire.")
+		}
+
+		c.Set(questionnaireIDKey, questionnaireID)
+
+		return next(c)
+	}
+}
+
+func getUserID(c echo.Context) (string, error) {
+	rowUserID := c.Get(userIDKey)
+	userID, ok := rowUserID.(string)
+	if !ok {
+		return "", errors.New("invalid context userID")
+	}
+
+	return userID, nil
+}
+
+func getQuestionnaireID(c echo.Context) (int, error) {
+	rowQuestionnaireID := c.Get(questionnaireIDKey)
+	questionnaireID, ok := rowQuestionnaireID.(int)
+	if !ok {
+		return 0, errors.New("invalid context userID")
+	}
+
+	return questionnaireID, nil
+}

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -1,6 +1,7 @@
 package router
 
 import (
+	"fmt"
 	"net/http"
 	"strconv"
 	"strings"
@@ -14,7 +15,6 @@ import (
 
 // GetQuestionnaires GET /questionnaires
 func GetQuestionnaires(c echo.Context) error {
-
 	questionnaires, pageMax, err := model.GetQuestionnaires(c, c.QueryParam("nontargeted") == "true")
 	if err != nil {
 		return err
@@ -28,7 +28,6 @@ func GetQuestionnaires(c echo.Context) error {
 
 // PostQuestionnaire POST /questionnaires
 func PostQuestionnaire(c echo.Context) error {
-
 	req := struct {
 		Title          string    `json:"title"`
 		Description    string    `json:"description"`
@@ -93,12 +92,12 @@ func PostQuestionnaire(c echo.Context) error {
 	})
 }
 
-// GetQuestionnaire GET /questionnaires/:id
+// GetQuestionnaire GET /questionnaires/:questionnaireID
 func GetQuestionnaire(c echo.Context) error {
-	questionnaireID, err := strconv.Atoi(c.Param("id"))
+	strQuestionnaireID := c.Param("questionnaireID")
+	questionnaireID, err := strconv.Atoi(strQuestionnaireID)
 	if err != nil {
-		c.Logger().Error(err)
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid questionnaireID:%s(error: %w)", strQuestionnaireID, err))
 	}
 
 	questionnaire, targets, administrators, respondents, err := model.GetQuestionnaireInfo(c, questionnaireID)
@@ -120,12 +119,11 @@ func GetQuestionnaire(c echo.Context) error {
 	})
 }
 
-// EditQuestionnaire PATCH /questonnaires/:id
+// EditQuestionnaire PATCH /questonnaires/:questionnaireID
 func EditQuestionnaire(c echo.Context) error {
-
-	questionnaireID, err := strconv.Atoi(c.Param("id"))
+	questionnaireID, err := getQuestionnaireID(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaireID: %w", err))
 	}
 
 	req := struct {
@@ -170,12 +168,11 @@ func EditQuestionnaire(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// DeleteQuestionnaire DELETE /questonnaires/:id
+// DeleteQuestionnaire DELETE /questonnaires/:questionnaireID
 func DeleteQuestionnaire(c echo.Context) error {
-
-	questionnaireID, err := strconv.Atoi(c.Param("id"))
+	questionnaireID, err := getQuestionnaireID(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest)
+		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaireID: %w", err))
 	}
 
 	if err := model.DeleteQuestionnaire(c, questionnaireID); err != nil {
@@ -193,12 +190,12 @@ func DeleteQuestionnaire(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// GetQuestions GET /questionnaires/:id/questions
+// GetQuestions GET /questionnaires/:questionnaireID/questions
 func GetQuestions(c echo.Context) error {
-	questionnaireID, err := strconv.Atoi(c.Param("id"))
+	strQuestionnaireID := c.Param("questionnaireID")
+	questionnaireID, err := strconv.Atoi(strQuestionnaireID)
 	if err != nil {
-		c.Logger().Error(err)
-		return err
+		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid questionnaireID:%s(error: %w)", strQuestionnaireID, err))
 	}
 
 	allquestions, err := model.GetQuestions(c, questionnaireID)

--- a/router/results.go
+++ b/router/results.go
@@ -2,6 +2,7 @@ package router
 
 import (
 	"errors"
+	"fmt"
 	"net/http"
 	"strconv"
 
@@ -40,19 +41,29 @@ func checkResponseConfirmable(c echo.Context, questionnaireID int) error {
 
 	switch resSharedTo {
 	case "administrators":
-		AmAdmin, err := model.CheckAdmin(c, questionnaireID)
+		userID, err := getUserID(c)
 		if err != nil {
-			return err
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get userID: %w", err))
 		}
-		if !AmAdmin {
+
+		isAdmin, err := model.CheckAdmin(userID, questionnaireID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if you are administrator: %w", err))
+		}
+		if !isAdmin {
 			return echo.NewHTTPError(http.StatusUnauthorized)
 		}
 	case "respondents":
-		AmAdmin, err := model.CheckAdmin(c, questionnaireID)
+		userID, err := getUserID(c)
 		if err != nil {
-			return err
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get userID: %w", err))
 		}
-		if !AmAdmin {
+
+		isAdmin, err := model.CheckAdmin(userID, questionnaireID)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to check if you are administrator: %w", err))
+		}
+		if !isAdmin {
 			isRespondent, err := model.CheckRespondent(c, questionnaireID)
 			if err != nil {
 				return err

--- a/router/router.go
+++ b/router/router.go
@@ -1,39 +1,21 @@
 package router
 
 import (
-	"net/http"
-
 	"github.com/labstack/echo"
-
-	"github.com/traPtitech/anke-to/model"
 )
-
-// UserAuthenticate traPのメンバーかの認証
-func UserAuthenticate() echo.MiddlewareFunc {
-	return func(next echo.HandlerFunc) echo.HandlerFunc {
-		return func(c echo.Context) error {
-			// トークンを持たないユーザはアクセスできない
-			if model.GetUserID(c) == "-" {
-				return echo.NewHTTPError(http.StatusUnauthorized, "You are not logged in")
-			}
-
-			return next(c)
-		}
-	}
-}
 
 // SetRouting ルーティングの設定
 func SetRouting(e *echo.Echo) {
-	api := e.Group("/api", UserAuthenticate())
+	api := e.Group("/api", UserAuthenticate)
 	{
 		apiQuestionnnaires := api.Group("/questionnaires")
 		{
 			apiQuestionnnaires.GET("", GetQuestionnaires)
 			apiQuestionnnaires.POST("", PostQuestionnaire)
-			apiQuestionnnaires.GET("/:id", GetQuestionnaire)
-			apiQuestionnnaires.PATCH("/:id", EditQuestionnaire)
-			apiQuestionnnaires.DELETE("/:id", DeleteQuestionnaire)
-			apiQuestionnnaires.GET("/:id/questions", GetQuestions)
+			apiQuestionnnaires.GET("/:questionnaireID", GetQuestionnaire)
+			apiQuestionnnaires.PATCH("/:questionnaireID", EditQuestionnaire, QuestionnaireAdministratorAuthenticate)
+			apiQuestionnnaires.DELETE("/:questionnaireID", DeleteQuestionnaire, QuestionnaireAdministratorAuthenticate)
+			apiQuestionnnaires.GET("/:questionnaireID/questions", GetQuestions)
 		}
 
 		apiQuestions := api.Group("/questions")


### PR DESCRIPTION
DELETE /questionnaires/:id,PATCH /questionnaires/:idで権限確認が行われておらず、任意の人がアンケートの修正・削除を出来る状態になっていた問題を修正した。
現状のエンドポイントだと消せないアンケートが出来てしまう可能性があったため、`@temma`, `@sappi_red`, `@ryoha`, `@mazrean`, `@YumizSui`, `@pure_white_404`(SysAdリーダー、クライアントのリーダー、サーバーサイド担当)にハードコーディングでエンドポイントを直で叩けば任意のアンケートを削除できる権限を与えている。
Close #241 #242 