### PR TITLE
collation修正

### DIFF
--- a/model/db.go
+++ b/model/db.go
@@ -47,7 +47,7 @@ func EstablishConnection() (*gorm.DB, error) {
 	_db, err := gorm.Open("mysql", fmt.Sprintf("%s:%s@tcp(%s:3306)/%s", user, pass, host, dbname)+"?parseTime=true&loc=Asia%2FTokyo&charset=utf8mb4")
 	db = _db
 	db = db.BlockGlobalUpdate(true)
-	db = db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci")
+	db = db.Set("gorm:table_options", "ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci")
 
 	return db, err
 }


### PR DESCRIPTION
>utf8mb4_unicode_ci
A = a 区別しない
:sushi: = :beer: 区別しない
は=ぱ=ば 区別しない

らしいので`utf8mb4_general_ci`へ変更。
https://qiita.com/tfunato/items/e48ad0a37b8244a788f6#collation
ref #318 