### PR TITLE
ciの時間短縮

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -15,10 +15,20 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - uses: actions/cache@v2
+        with:
+        path: |
+          /var/lib/docker/buildkit
+        key: ${{ runner.os }}-buildkit-${{ hashFiles('**/go.sum') }}
       - name: Login GitHub Registry
         run: docker login docker.pkg.github.com -u traPtitech -p ${{ secrets.GITHUB_TOKEN }}
       - name: Build Image
-        run: docker build -f docker/staging/Dockerfile -t docker.pkg.github.com/traptitech/anke-to/${IMAGE_NAME}:${IMAGE_TAG} .
+        env:
+          DOCKER_BUILDKIT: 1
+        run: |
+          docker build \
+          --cache-from=docker.pkg.github.com/traptitech/anke-to/${IMAGE_NAME}:${IMAGE_TAG} --build-arg BUILDKIT_INLINE_CACHE=1 \
+          -f docker/staging/Dockerfile -t docker.pkg.github.com/traptitech/anke-to/${IMAGE_NAME}:${IMAGE_TAG} .
       - name: Push image to GitHub Registry
         run: docker push docker.pkg.github.com/traptitech/anke-to/${IMAGE_NAME}:${IMAGE_TAG}
   deploy-staging:

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -1,23 +1,30 @@
+# syntax = docker/dockerfile:1.0-experimental
+
 # build backend
 FROM golang:1.15.3-alpine as server-build
-RUN apk add --update --no-cache git
+RUN --mount=type=cache,id=aptgit,target=/var/cache/apt --mount=type=cache,target=/var/lib/apt \
+  apk add --update git
 
 WORKDIR /github.com/traPtitech/anke-to
 
 COPY go.mod go.sum ./
-RUN go mod download
+RUN --mount=type=cache,id=gomod,target=/go/pkg/mod/cache \
+  go mod download
 
 COPY . .
 
-RUN go build -o /anke-to -ldflags "-s -w"
+RUN --mount=type=cache,id=gobuild,target=/root/.cache/go-build \
+  go build -o /anke-to -ldflags "-s -w"
 
 #build frontend
 FROM node:12-alpine as client-build
 WORKDIR /github.com/traPtitech/anke-to/client
 COPY client/package.json client/package-lock.json ./
-RUN npm ci
+RUN --mount=type=cache,id=npmci,target=/root/.npm \
+  npm ci --prefer-offline
 COPY client .
-RUN npm run staging-build
+RUN --mount=type=cache,id=vuebuild,target=/github.com/traPtitech/anke-to/client/node_modules/.cache \
+  npm run staging-build
 
 
 # run


### PR DESCRIPTION
- staging環境用のDockerfileのキャッシュの調整
- cache-fromをして最終ステージのキャッシュが効くように

cache-fromで最終ステージ以外のキャッシュが聞かないのは意図的にやっている(stagingへのデプロイの感覚を考えると`go mod`のlayerのキャッシュとかはしても聞かない確率が高いので、より効く可能性の高いBuildKitの方のキャッシュのみ効く状態にしている)。