### PR TITLE
「回答済みユーザーのみに公開」で管理者も見れるように

### DIFF
--- a/client/src/bin/common.js
+++ b/client/src/bin/common.js
@@ -168,7 +168,8 @@ export default {
     return (
       information.res_shared_to === 'public' ||
       (information.res_shared_to === 'administrators' && administrates) ||
-      (information.res_shared_to === 'respondents' && hasResponded)
+      (information.res_shared_to === 'respondents' && hasResponded) ||
+      (information.res_shared_to === 'respondents' && administrates)
     )
   },
   getUserLists (targets, respondents, administrators) {


### PR DESCRIPTION
クライアント側で管理者に「閲覧権限がない」と表示されるようになっていたので変更した。
Close #388 