### PR TITLE
codecovのトークンの削除

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,7 +86,6 @@ jobs:
       - name: Upload coverage data
         uses: codecov/codecov-action@v1
         with:
-          token: ${{ secrets.CODECOV_TOKEN }}
           file: ./coverage.txt
           yml: ./codecov.yml
       - uses: actions/upload-artifact@v1


### PR DESCRIPTION
[Bash Uploader Security Update](https://about.codecov.io/security-update/)への対応。ciではトークンが要らなくなっているらしいので使わないようにした。