### PR TITLE
install python for node-gyp

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,6 +14,7 @@ RUN go build -o /anke-to -ldflags "-s -w"
 #build frontend
 FROM node:16-alpine as client-build
 WORKDIR /github.com/traPtitech/anke-to/client
+RUN apk add --update --no-cache python
 COPY client/package.json client/package-lock.json ./
 RUN npm ci
 COPY client .

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -15,6 +15,7 @@ RUN go build -o /anke-to -ldflags "-s -w"
 #build frontend
 FROM node:16-alpine as client-build
 WORKDIR /github.com/traPtitech/anke-to/client
+RUN apk add --update --no-cache python
 COPY client/package.json client/package-lock.json ./
 RUN npm ci --prefer-offline
 COPY client .


### PR DESCRIPTION
node-gypがpython3を使うようになっていてdocker imageのbuildができなくなっていたので修正した。