### PR TITLE
DBスキーマ修正案

### DIFF
--- a/docs/db_schema_new.md
+++ b/docs/db_schema_new.md
@@ -1,13 +1,13 @@
-# db スキーマ
+# dbスキーマ
 
 ### administrators
 
-アンケートの運営 (編集等ができる人)
+アンケートの管理者 (編集等ができる人)
 
-| Field            | Type     | Null | Key | Default | Extra | 説明など |
-| ---------------- | -------- | ---- | --- | ------- | ----- | -------- |
-| questionnaire_id | int(11)  | NO   | PRI | _NULL_  |
-| user_traqid      | char(30) | NO   | PRI | _NULL_  |
+| Field            | Type        | Null | Key | Default | Extra | 説明など |
+| ---------------- | ----------- | ---- | --- | ------- | ----- | -------- |
+| questionnaire_id | int(11)     | NO   | PRI | _NULL_  |       |          |
+| user_traqid      | varchar(32) | NO   | PRI | _NULL_  |       |          |
 
 ### options
 
@@ -15,41 +15,63 @@
 
 | Field       | Type    | Null | Key | Default | Extra          | 説明など           |
 | ----------- | ------- | ---- | --- | ------- | -------------- | ------------------ |
-| id          | int(11) | NO   | PRI | _NULL_  | auto_increment |
+| id          | int(11) | NO   | PRI | _NULL_  | AUTO_INCREMENT |
 | question_id | int(11) | NO   | MUL | _NULL_  |                | どの質問の選択肢か |
 | option_num  | int(11) | NO   |     | _NULL_  |                | 何番目の選択肢か   |
 | body        | text    | YES  |     | _NULL_  |                | 選択肢の内容       |
 
-### question
+### questions
 
 質問内容
 
 | Field            | Type       | Null | Key  | Default           | Extra          | 説明など                                                     |
 | ---------------- | ---------- | ---- | ---- | ----------------- | -------------- | ------------------------------------------------------------ |
-| id               | int(11)    | NO   | PRI  | _NULL_            | auto_increment |                                                              |
+| id               | int(11)    | NO   | PRI  | _NULL_            | AUTO_INCREMENT |                                                              |
 | questionnaire_id | int(11)    | YES  |      | _NULL_            |                | どのアンケートの質問か                                       |
 | page_num         | int(11)    | NO   |      | _NULL_            |                | アンケートの何ページ目の質問か                               |
 | question_num     | int(11)    | NO   |      | _NULL_            |                | アンケートの質問のうち、何問目か                             |
-| type             | char(20)   | NO   |      | _NULL_            |                | どのタイプの質問か ("Text","TextArea",  "Number", "MultipleChoice", "Checkbox", "Dropdown", "LinearScale", "Date", "Time") |
+| type             | int(11)    | NO   | MUL  | _NULL_            |                | どのタイプの質問か |
 | body             | text       | YES  |      | _NULL_            |                | 質問の内容                                                   |
-| is_required      | tinyint(4) | NO   |      | 0                 |                | 回答が必須である (1) , ない(0)                               |
-| deleted_at       | timestamp  | YES  |      | _NULL_            |                | 質問が削除された日時 (削除されていない場合は NULL)           |
-| created_at       | timestamp  | NO   |      | CURRENT_TIMESTAMP |                | 質問が作成された日時                                         |
+| is_required      | boolean | NO   |      | 0                 |                | 回答が必須でか                               |
+| created_at       | datetime  | NO   |      | CURRENT_TIMESTAMP |                | 質問が作成された日時                                         |
+| deleted_at       | datetime  | YES  |      | _NULL_            |                | 質問が削除された日時 (削除されていない場合はNULL)           |
+
+### question_types
+
+質問の種類。
+'Text'、'TextArea'、'Number'、'MultipleChoice'、'Checkbox', 'Dropdown', 'LinearScale', 'Date', 'Time'。
+
+| Field  | Type       | Null | Key  | Default           | Extra          | 説明など |
+| ------ | ---------- | ---- | ---- | ----------------- | -------------- | -------- |
+| id     | int(11)    | NO   | PRI  | _NULL_            | AUTO_INCREMENT |          |
+| name   | int(11)    | NO   |      | _NULL_            |                |          |
+| active | boolean    | NO   |      | true              |                |          |
 
 ### questionnaires
 
 アンケートの情報
 
-| Field          | Type      | Null | Key | Default           | Extra          | 説明など                                                                                                                |
-| -------------- | --------- | ---- | --- | ----------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
-| id             | int(11)   | NO   | PRI | _NULL_            | auto_increment |
-| title          | char(50)  | NO   | MUL | _NULL_            |                | アンケートのタイトル                                                                                                    |
-| description    | text      | NO   |     | _NULL_            |                | アンケートの説明                                                                                                        |
-| res_time_limit | timestamp | YES  |     | _NULL_            |                | 回答の締切日時 (締切がない場合は NULL)                                                                                  |
-| deleted_at     | timestamp | YES  |     | _NULL_            |                | アンケートが削除された日時 (削除されていない場合は NULL)                                                                |
-| res_shared_to  | char(30)  | NO   |     | administrators    |                | アンケートの結果を, 運営は見られる ("administrators"), 回答済みの人は見られる ("respondents") 誰でも見られる ("public") |
-| created_at     | timestamp | NO   |     | CURRENT_TIMESTAMP |                | アンケートが作成された日時                                                                                              |
-| modified_at    | timestamp | NO   |     | CURRENT_TIMESTAMP |                | アンケートが更新された日時                                                                                              |
+| Field          | Type     | Null | Key | Default           | Extra          | 説明など                                                                                                                |
+| -------------- | -------- | ---- | --- | ----------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| id             | int(11)  | NO   | PRI | _NULL_            | AUTO_INCREMENT |
+| title          | char(50) | NO   | MUL | _NULL_            |                | アンケートのタイトル |
+| description    | text     | NO   |     | _NULL_            |                | アンケートの説明                                                                                                        |
+| res_time_limit | datetime | YES  |     | _NULL_            |                | 回答の締切日時 (締切がない場合はNULL) |
+| res_shared_to  | int(11)  | NO   | MUL | _NULL_            |                |                                       |
+| created_at     | datetime | NO   |     | CURRENT_TIMESTAMP |                | アンケートが作成された日時                                                                                              |
+| updated_at     | datetime | NO   |     | CURRENT_TIMESTAMP |                | アンケートが更新された日時                                                                                              |
+| deleted_at     | datetime | YES  |     | _NULL_            |                | アンケートが削除された日時 (削除されていない場合はNULL)                                                                |
+
+### res_share_types
+
+アンケート結果の公開範囲の種類。
+アンケートの結果を、運営は見られる ("administrators")、回答済みの人は見られる ("respondents")、誰でも見られる ("public")。
+
+| Field  | Type       | Null | Key  | Default           | Extra          | 説明など |
+| ------ | ---------- | ---- | ---- | ----------------- | -------------- | -------- |
+| id     | int(11)    | NO   | PRI  | _NULL_            | AUTO_INCREMENT |          |
+| name   | int(11)    | NO   |      | _NULL_            |                |          |
+| active | boolean    | NO   |      | true              |                |          |
 
 ### respondents
 
@@ -57,40 +79,40 @@
 
 | Field            | Type      | Null | Key | Default           | Extra          | 説明など                                            |
 | ---------------- | --------- | ---- | --- | ----------------- | -------------- | --------------------------------------------------- |
-| response_id      | int(11)   | NO   | PRI | _NULL_            | auto_increment | 一つのアンケートに対する一つの回答ごとに振られる ID |
+| response_id      | int(11)   | NO   | PRI | _NULL_            | AUTO_INCREMENT | 1つのアンケートに対する1つの回答ごとに振られるID |
 | questionnaire_id | int(11)   | NO   | MUL | _NULL_            |                | どのアンケートへの回答か                            |
-| user_traqid      | char(30)  | YES  | MUL | _NULL_            |                | 回答者の traQID                                     |
-| modified_at      | timestamp | NO   |     | CURRENT_TIMESTAMP |                | 回答が変更された日時                                |
-| submitted_at     | timestamp | YES  |     | _NULL_            |                | 回答が送信された日時 (未送信の場合は NULL)          |
-| deleted_at       | timestamp | YES  |     | _NULL_            |                | 回答が破棄された日時 (破棄されていない場合は NULL)  |
+| user_traqid      | varchar(32)  | YES  | MUL | _NULL_            |                | 回答者のtraQID                                     |
+| submitted_at     | datetime | YES  |     | _NULL_            |                | 回答が送信された日時 (未送信の場合はNULL)          |
+| updated_at       | datetime | NO   |     | CURRENT_TIMESTAMP |                | 回答が変更された日時                                |
+| deleted_at       | datetime | YES  |     | _NULL_            |                | 回答が破棄された日時 (破棄されていない場合はNULL)  |
 
-### response
+### responses
 
 回答
 
 | Field       | Type      | Null | Key | Default           | Extra | 説明など                                            |
 | ----------- | --------- | ---- | --- | ----------------- | ----- | --------------------------------------------------- |
-| response_id | int(11)   | NO   | MUL | _NULL_            |       | 一つのアンケートに対する一つの回答ごとに振られる ID |
+| response_id | int(11)   | NO   | MUL | _NULL_            |       | 1つのアンケートに対する1つの回答ごとに振られるID |
 | question_id | int(11)   | NO   | MUL | _NULL_            |       | どの質問への回答か                                  |
 | body        | text      | YES  |     | _NULL_            |       | 回答の内容                                          |
-| modified_at | timestamp | NO   |     | CURRENT_TIMESTAMP |       | 回答が変更された日時                                |
-| deleted_at  | timestamp | YES  |     | _NULL_            |       | 回答が破棄された日時 (破棄されていない場合は NULL)  |
+| updated_at  | datetime  | NO   |     | CURRENT_TIMESTAMP |       | 回答が変更された日時                                |
+| deleted_at  | datetime  | YES  |     | _NULL_            |       | 回答が破棄された日時 (破棄されていない場合はNULL)  |
 
 ### scale_labels
 
 目盛り (LinearScale) 形式の質問の左右のラベル
 
-| Field             | Type    | Null | Key | Default | Extra | 説明など                       |
-| ----------------- | ------- | ---- | --- | ------- | ----- | ------------------------------ |
-| question_id       | int(11) | NO   | PRI | _NULL_  |       | どの質問のラベルか             |
-| scale_label_left  | text    | YES  |     | _NULL_  |       | 左側のラベル (ない場合は NULL) |
-| scale_label_right | text    | YES  |     | _NULL_  |       | 右側のラベル (ない場合は NULL) |
-| scale_min         | int(11) | YES  |     | _NULL_  |       | スケールの最小値               |
-| scale_max         | int(11) | YES  |     | _NULL_  |       | スケールの最大値               |
+| Field             | Type        | Null | Key | Default | Extra | 説明など                       |
+| ----------------- | ----------- | ---- | --- | ------- | ----- | ------------------------------ |
+| question_id       | int(11)     | NO   | PRI | _NULL_  |       | どの質問のラベルか             |
+| scale_label_left  | varchar(50) | YES  |     | _NULL_  |       | 左側のラベル (ない場合はNULL) |
+| scale_label_right | varchar(50) | YES  |     | _NULL_  |       | 右側のラベル (ない場合はNULL) |
+| scale_min         | int(11)     | YES  |     | _NULL_  |       | スケールの最小値               |
+| scale_max         | int(11)     | YES  |     | _NULL_  |       | スケールの最大値               |
 
 ### validations
 
-`Number`の値制限，`Text`の正規表現によるパターンマッチング．
+`Number`の値制限、`Text`の正規表現によるパターンマッチング。
 
 | Field         | Type    | Null | Key  | Default | Extra | 説明など           |
 | ------------- | ------- | ---- | ---- | ------- | ----- | ------------------ |
@@ -103,7 +125,7 @@
 
 アンケートの対象者
 
-| Field            | Type     | Null | Key | Default | Extra | 説明など |
-| ---------------- | -------- | ---- | --- | ------- | ----- | -------- |
-| questionnaire_id | int(11)  | NO   | PRI | _NULL_  |
-| user_traqid      | char(30) | NO   | PRI | _NULL_  |
+| Field            | Type        | Null | Key | Default | Extra | 説明など |
+| ---------------- | ----------- | ---- | --- | ------- | ----- | -------- |
+| questionnaire_id | int(11)     | NO   | PRI | _NULL_  |       |          |
+| user_traqid      | varchar(32) | NO   | PRI | _NULL_  |       |          |

--- a/docs/db_schema_new.md
+++ b/docs/db_schema_new.md
@@ -1,0 +1,109 @@
+# db スキーマ
+
+### administrators
+
+アンケートの運営 (編集等ができる人)
+
+| Field            | Type     | Null | Key | Default | Extra | 説明など |
+| ---------------- | -------- | ---- | --- | ------- | ----- | -------- |
+| questionnaire_id | int(11)  | NO   | PRI | _NULL_  |
+| user_traqid      | char(30) | NO   | PRI | _NULL_  |
+
+### options
+
+選択肢
+
+| Field       | Type    | Null | Key | Default | Extra          | 説明など           |
+| ----------- | ------- | ---- | --- | ------- | -------------- | ------------------ |
+| id          | int(11) | NO   | PRI | _NULL_  | auto_increment |
+| question_id | int(11) | NO   | MUL | _NULL_  |                | どの質問の選択肢か |
+| option_num  | int(11) | NO   |     | _NULL_  |                | 何番目の選択肢か   |
+| body        | text    | YES  |     | _NULL_  |                | 選択肢の内容       |
+
+### question
+
+質問内容
+
+| Field            | Type       | Null | Key  | Default           | Extra          | 説明など                                                     |
+| ---------------- | ---------- | ---- | ---- | ----------------- | -------------- | ------------------------------------------------------------ |
+| id               | int(11)    | NO   | PRI  | _NULL_            | auto_increment |                                                              |
+| questionnaire_id | int(11)    | YES  |      | _NULL_            |                | どのアンケートの質問か                                       |
+| page_num         | int(11)    | NO   |      | _NULL_            |                | アンケートの何ページ目の質問か                               |
+| question_num     | int(11)    | NO   |      | _NULL_            |                | アンケートの質問のうち、何問目か                             |
+| type             | char(20)   | NO   |      | _NULL_            |                | どのタイプの質問か ("Text","TextArea",  "Number", "MultipleChoice", "Checkbox", "Dropdown", "LinearScale", "Date", "Time") |
+| body             | text       | YES  |      | _NULL_            |                | 質問の内容                                                   |
+| is_required      | tinyint(4) | NO   |      | 0                 |                | 回答が必須である (1) , ない(0)                               |
+| deleted_at       | timestamp  | YES  |      | _NULL_            |                | 質問が削除された日時 (削除されていない場合は NULL)           |
+| created_at       | timestamp  | NO   |      | CURRENT_TIMESTAMP |                | 質問が作成された日時                                         |
+
+### questionnaires
+
+アンケートの情報
+
+| Field          | Type      | Null | Key | Default           | Extra          | 説明など                                                                                                                |
+| -------------- | --------- | ---- | --- | ----------------- | -------------- | ----------------------------------------------------------------------------------------------------------------------- |
+| id             | int(11)   | NO   | PRI | _NULL_            | auto_increment |
+| title          | char(50)  | NO   | MUL | _NULL_            |                | アンケートのタイトル                                                                                                    |
+| description    | text      | NO   |     | _NULL_            |                | アンケートの説明                                                                                                        |
+| res_time_limit | timestamp | YES  |     | _NULL_            |                | 回答の締切日時 (締切がない場合は NULL)                                                                                  |
+| deleted_at     | timestamp | YES  |     | _NULL_            |                | アンケートが削除された日時 (削除されていない場合は NULL)                                                                |
+| res_shared_to  | char(30)  | NO   |     | administrators    |                | アンケートの結果を, 運営は見られる ("administrators"), 回答済みの人は見られる ("respondents") 誰でも見られる ("public") |
+| created_at     | timestamp | NO   |     | CURRENT_TIMESTAMP |                | アンケートが作成された日時                                                                                              |
+| modified_at    | timestamp | NO   |     | CURRENT_TIMESTAMP |                | アンケートが更新された日時                                                                                              |
+
+### respondents
+
+アンケートごとの回答者
+
+| Field            | Type      | Null | Key | Default           | Extra          | 説明など                                            |
+| ---------------- | --------- | ---- | --- | ----------------- | -------------- | --------------------------------------------------- |
+| response_id      | int(11)   | NO   | PRI | _NULL_            | auto_increment | 一つのアンケートに対する一つの回答ごとに振られる ID |
+| questionnaire_id | int(11)   | NO   | MUL | _NULL_            |                | どのアンケートへの回答か                            |
+| user_traqid      | char(30)  | YES  | MUL | _NULL_            |                | 回答者の traQID                                     |
+| modified_at      | timestamp | NO   |     | CURRENT_TIMESTAMP |                | 回答が変更された日時                                |
+| submitted_at     | timestamp | YES  |     | _NULL_            |                | 回答が送信された日時 (未送信の場合は NULL)          |
+| deleted_at       | timestamp | YES  |     | _NULL_            |                | 回答が破棄された日時 (破棄されていない場合は NULL)  |
+
+### response
+
+回答
+
+| Field       | Type      | Null | Key | Default           | Extra | 説明など                                            |
+| ----------- | --------- | ---- | --- | ----------------- | ----- | --------------------------------------------------- |
+| response_id | int(11)   | NO   | MUL | _NULL_            |       | 一つのアンケートに対する一つの回答ごとに振られる ID |
+| question_id | int(11)   | NO   | MUL | _NULL_            |       | どの質問への回答か                                  |
+| body        | text      | YES  |     | _NULL_            |       | 回答の内容                                          |
+| modified_at | timestamp | NO   |     | CURRENT_TIMESTAMP |       | 回答が変更された日時                                |
+| deleted_at  | timestamp | YES  |     | _NULL_            |       | 回答が破棄された日時 (破棄されていない場合は NULL)  |
+
+### scale_labels
+
+目盛り (LinearScale) 形式の質問の左右のラベル
+
+| Field             | Type    | Null | Key | Default | Extra | 説明など                       |
+| ----------------- | ------- | ---- | --- | ------- | ----- | ------------------------------ |
+| question_id       | int(11) | NO   | PRI | _NULL_  |       | どの質問のラベルか             |
+| scale_label_left  | text    | YES  |     | _NULL_  |       | 左側のラベル (ない場合は NULL) |
+| scale_label_right | text    | YES  |     | _NULL_  |       | 右側のラベル (ない場合は NULL) |
+| scale_min         | int(11) | YES  |     | _NULL_  |       | スケールの最小値               |
+| scale_max         | int(11) | YES  |     | _NULL_  |       | スケールの最大値               |
+
+### validations
+
+`Number`の値制限，`Text`の正規表現によるパターンマッチング．
+
+| Field         | Type    | Null | Key  | Default | Extra | 説明など           |
+| ------------- | ------- | ---- | ---- | ------- | ----- | ------------------ |
+| question_id   | int(11) | YES  | PRI  | _NULL_  |       | どの質問についてか |
+| regex_pattern | text    | YES  |      | _NULL_  |       | 正規表現           |
+| min_bound     | text    | YES  |      | _NULL_  |       | 数値の下界         |
+| max_bound     | text    | YES  |      | _NULL_  |       | 数値の上界         |
+
+### targets
+
+アンケートの対象者
+
+| Field            | Type     | Null | Key | Default | Extra | 説明など |
+| ---------------- | -------- | ---- | --- | ------- | ----- | -------- |
+| questionnaire_id | int(11)  | NO   | PRI | _NULL_  |
+| user_traqid      | char(30) | NO   | PRI | _NULL_  |


### PR DESCRIPTION
主な変更は
- timestampをdatetimeに
    - timestampで格納できる時間が2039年だかまでなので
- 単数形テーブル名を複数形に
    - ずっと複数形に単数形が混ざっているのが違和感あった
- modified_atをupdated_atに
    - GORM周りでいろいろ面倒なので
- traQ IDのカラムをchar(30)からvarchar(32)に
    - traQに合わせて
- `questions.type`、`questionnaires.res_shared_to`をenumに
    - 想定外の値がミスで入るのを防いでおきたい
- `questions.is_required`をtinyint(4)からbooleanに
    - こちらも想定外の値がミスで入るのを防いでおきたい
- `scale_labels.scale_label_left`、`scale_labels.scale_label_right`をtextからvarchar(50)に
    - そう長い値が入る場所ではないのと、index貼れなくなったりして不都合が多いので

このうち
- `questions.type`、`questionnaires.res_shared_to`をenumに
- `questions.is_required`をtinyint(4)からbooleanに
- `scale_labels.scale_label_left`、`scale_labels.scale_label_right`をtextからvarchar(50)に

はもともと格納可能だったものの一部が格納できなくなるので、現時点で入っているものが問題ないかクエリを叩いて確認ずみ。
<details>

```
MariaDB [cry3f_anke_to]> select * from question where type NOT IN('Text', 'TextArea', 'Number', 'MultipleChoice', 'Checkbox', 'Dropdown', 'LinearScale', 'Date', 'Time');
Empty set (0.004 sec)

MariaDB [cry3f_anke_to]> select * from questionnaires where res_shared_to NOT IN('administrators', 'respondents', 'public');
Empty set (0.004 sec)

MariaDB [cry3f_anke_to]> select * from question where is_required NOT IN(0,1);
Empty set (0.021 sec)

MariaDB [cry3f_anke_to]> select MAX(LENGTH(scale_label_left)) from scale_labels;
+-------------------------------+
| MAX(LENGTH(scale_label_left)) |
+-------------------------------+
|                            33 |
+-------------------------------+
1 row in set (0.002 sec)

MariaDB [cry3f_anke_to]> select MAX(LENGTH(scale_label_right)) from scale_labels;
+--------------------------------+
| MAX(LENGTH(scale_label_right)) |
+--------------------------------+
|                             26 |
+--------------------------------+
1 row in set (0.001 sec)

```
</details>

アプリケーション側の対応は後で行う。
ref #569 