### PR TITLE
環境変数がない時の処理修正

### DIFF
--- a/main.go
+++ b/main.go
@@ -12,7 +12,10 @@ import (
 )
 
 func main() {
-	env := os.Getenv("ANKE-TO_ENV")
+	env, ok := os.LookupEnv("ANKE-TO_ENV")
+	if !ok {
+		panic("no ANKE-TO_ENV")
+	}
 	logOn := env == "pprof" || env == "dev"
 
 	if len(os.Args) > 1 {
@@ -48,7 +51,10 @@ func main() {
 		}()
 	}
 
-	port := os.Getenv("PORT")
+	port, ok := os.LookupEnv("PORT")
+	if !ok {
+		panic("no PORT")
+	}
 
 	SetRouting(port)
 }

--- a/model/db.go
+++ b/model/db.go
@@ -24,23 +24,23 @@ var (
 
 // EstablishConnection DBと接続
 func EstablishConnection() (*gorm.DB, error) {
-	user := os.Getenv("MARIADB_USERNAME")
-	if user == "" {
+	user, ok := os.LookupEnv("MARIADB_USERNAME")
+	if !ok {
 		user = "root"
 	}
 
-	pass := os.Getenv("MARIADB_PASSWORD")
-	if pass == "" {
+	pass, ok := os.LookupEnv("MARIADB_PASSWORD")
+	if !ok {
 		pass = "password"
 	}
 
-	host := os.Getenv("MARIADB_HOSTNAME")
-	if host == "" {
+	host, ok := os.LookupEnv("MARIADB_HOSTNAME")
+	if !ok {
 		host = "localhost"
 	}
 
-	dbname := os.Getenv("MARIADB_DATABASE")
-	if dbname == "" {
+	dbname, ok := os.LookupEnv("MARIADB_DATABASE")
+	if !ok {
 		dbname = "anke-to"
 	}
 


### PR DESCRIPTION
`os.Getenv`を使っているが`os.Lookup`の方が適切な箇所が複数あったので修正した。
Close #380 