### PR TITLE
ANKE-TO_ENVのデフォルトをproductionに

### DIFF
--- a/docker/staging/docker-compose.yaml
+++ b/docker/staging/docker-compose.yaml
@@ -6,7 +6,6 @@ services:
       context: ../..
       dockerfile: docker/staging/Dockerfile
     environment:
-      ANKE-TO_ENV: dev
       PORT: :1323
       MARIADB_USERNAME: root
       MARIADB_PASSWORD: password

--- a/main.go
+++ b/main.go
@@ -14,7 +14,7 @@ import (
 func main() {
 	env, ok := os.LookupEnv("ANKE-TO_ENV")
 	if !ok {
-		panic("no ANKE-TO_ENV")
+		env = "production"
 	}
 	logOn := env == "pprof" || env == "dev"
 


### PR DESCRIPTION
#578 で環境変数がないときにpanicするようにしていたが、
productionでは空文字で通していたので、このままだと本番環境へのデプロイ時に落ちる。
ただ、productionなら空文字というのも微妙なのでデフォルトを"production"として、
productionでは"production"を値として設定するようにした。