### PR TITLE
回答を締めきれなくなっていた

### DIFF
--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -225,14 +225,6 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if req.ResTimeLimit.Valid {
-		isBefore := req.ResTimeLimit.ValueOrZero().Before(time.Now())
-		if isBefore {
-			c.Logger().Info(fmt.Sprintf(": %+v", req.ResTimeLimit))
-			return echo.NewHTTPError(http.StatusBadRequest, "res time limit is before now")
-		}
-	}
-
 	if err := q.UpdateQuestionnaire(
 		req.Title, req.Description, req.ResTimeLimit, req.ResSharedTo, questionnaireID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)


### PR DESCRIPTION
patchで現在時刻より前に回答期限を設定することで閉じていたため、#603 で回答を締め切ることができなくなっていた。
PATCHでは回答期限の制限を消して修正した。
