### PR TITLE
GET /responses/responseIDに認証追加

### DIFF
--- a/model/errors.go
+++ b/model/errors.go
@@ -23,4 +23,6 @@ var (
 	ErrTextMatching = errors.New("failed to match the pattern")
 	// ErrInvalidAnsweredParam invalid sort param
 	ErrInvalidAnsweredParam = errors.New("invalid answered param")
+	// ErrInvalidResponseID invalid response id
+	ErrInvalidResponseID = errors.New("invalid response id")
 )

--- a/model/questionnaires.go
+++ b/model/questionnaires.go
@@ -15,4 +15,5 @@ type IQuestionnaire interface {
 	GetTargettedQuestionnaires(userID string, answered string, sort string) ([]TargettedQuestionnaire, error)
 	GetQuestionnaireLimit(questionnaireID int) (null.Time, error)
 	GetResShared(questionnaireID int) (string, error)
+	GetResponseReadPrivilegeInfoByResponseID(userID string, responseID int) (*ResponseReadPrivilegeInfo, error)
 }

--- a/router.go
+++ b/router.go
@@ -55,7 +55,7 @@ func SetRouting(port string) {
 		apiResponses := echoAPI.Group("/responses")
 		{
 			apiResponses.POST("", api.PostResponse)
-			apiResponses.GET("/:responseID", api.GetResponse)
+			apiResponses.GET("/:responseID", api.GetResponse, api.ResponseReadAuthenticate)
 			apiResponses.PATCH("/:responseID", api.EditResponse, api.RespondentAuthenticate)
 			apiResponses.DELETE("/:responseID", api.DeleteResponse, api.RespondentAuthenticate)
 		}

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -1,0 +1,185 @@
+package router
+
+import (
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"strconv"
+	"testing"
+
+	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
+	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/anke-to/model"
+	"github.com/traPtitech/anke-to/model/mock_model"
+)
+
+type CallChecker struct {
+	IsCalled bool
+}
+
+func (cc *CallChecker) Handler(c echo.Context) error {
+	cc.IsCalled = true
+
+	return c.NoContent(http.StatusOK)
+}
+
+func TestResponseReadAuthenticate(t *testing.T) {
+	t.Parallel()
+
+	assertion := assert.New(t)
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockRespondent := mock_model.NewMockIRespondent(ctrl)
+	mockAdministrator := mock_model.NewMockIAdministrator(ctrl)
+	mockQuestionnaire := mock_model.NewMockIQuestionnaire(ctrl)
+	mockQuestion := mock_model.NewMockIQuestion(ctrl)
+
+	middleware := NewMiddleware(mockAdministrator, mockRespondent, mockQuestion, mockQuestionnaire)
+
+	type args struct {
+		isRespondent bool
+		CheckRespondentByResponseIDError error
+		haveReadPrivilege bool
+		GetResponseReadPrivilegeInfoByResponseIDError error
+		checkResponseReadPrivilegeError error
+	}
+	type expect struct {
+		statusCode int
+		isCalled bool
+	}
+	type test struct {
+		description string
+		args
+		expect
+	}
+
+	testCases := []test{
+		{
+			description: "この回答の回答者である場合通す",
+			args: args{
+				isRespondent: true,
+			},
+			expect: expect{
+				statusCode: http.StatusOK,
+				isCalled: true,
+			},
+		},
+		{
+			description: "CheckRespondentByResponseIDがエラーの場合500",
+			args: args{
+				CheckRespondentByResponseIDError: errors.New("error"),
+			},
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+				isCalled: false,
+			},
+		},
+		{
+			description: "この回答の回答者でなくてもhaveReadPrivilegeがtrueの場合通す",
+			args: args{
+				isRespondent: false,
+				haveReadPrivilege: true,
+			},
+			expect: expect{
+				statusCode: http.StatusOK,
+				isCalled: true,
+			},
+		},
+		{
+			description: "この回答の回答者でなく、haveReadPrivilegeがfalseの場合403",
+			args: args{
+				isRespondent: false,
+				haveReadPrivilege: false,
+			},
+			expect: expect{
+				statusCode: http.StatusForbidden,
+				isCalled: false,
+			},
+		},
+		{
+			description: "GetResponseReadPrivilegeInfoByResponseIDがErrInvalidResponseIDの場合400",
+			args: args{
+				isRespondent: false,
+				haveReadPrivilege: false,
+				GetResponseReadPrivilegeInfoByResponseIDError: model.ErrInvalidResponseID,
+			},
+			expect: expect{
+				statusCode: http.StatusBadRequest,
+				isCalled: false,
+			},
+		},
+		{
+			description: "GetResponseReadPrivilegeInfoByResponseIDがエラー(ErrInvalidResponseID以外)の場合500",
+			args: args{
+				isRespondent: false,
+				haveReadPrivilege: false,
+				GetResponseReadPrivilegeInfoByResponseIDError: errors.New("error"),
+			},
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+				isCalled: false,
+			},
+		},
+		{
+			description: "checkResponseReadPrivilegeがエラーの場合500",
+			args: args{
+				isRespondent: false,
+				haveReadPrivilege: false,
+				checkResponseReadPrivilegeError: errors.New("error"),
+			},
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+				isCalled: false,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		userID := "testUser"
+		responseID := 1
+		var responseReadPrivilegeInfo model.ResponseReadPrivilegeInfo
+		if testCase.args.checkResponseReadPrivilegeError != nil {
+			responseReadPrivilegeInfo = model.ResponseReadPrivilegeInfo{
+				ResSharedTo: "invalid value",
+			}
+		} else if testCase.args.haveReadPrivilege {
+			responseReadPrivilegeInfo = model.ResponseReadPrivilegeInfo{
+				ResSharedTo: "public",
+			}
+		} else {
+			responseReadPrivilegeInfo = model.ResponseReadPrivilegeInfo{
+				ResSharedTo: "administrators",
+			}
+		}
+
+		mockRespondent.
+			EXPECT().
+			CheckRespondentByResponseID(userID, responseID).
+			Return(testCase.args.isRespondent, testCase.args.CheckRespondentByResponseIDError)
+		if !testCase.args.isRespondent && testCase.args.CheckRespondentByResponseIDError == nil {
+			mockQuestionnaire.
+				EXPECT().
+				GetResponseReadPrivilegeInfoByResponseID(userID, responseID).
+				Return(&responseReadPrivilegeInfo, testCase.args.GetResponseReadPrivilegeInfoByResponseIDError)
+		}
+
+		e := echo.New()
+		req := httptest.NewRequest(http.MethodGet, "/", nil)
+		rec := httptest.NewRecorder()
+		c := e.NewContext(req, rec)
+		c.SetPath("/responses/:responseID")
+		c.SetParamNames("responseID")
+		c.SetParamValues(strconv.Itoa(responseID))
+		c.Set(userIDKey, userID)
+
+		callChecker := CallChecker{}
+
+		e.HTTPErrorHandler(middleware.ResponseReadAuthenticate(callChecker.Handler)(c), c)
+
+		assertion.Equalf(testCase.expect.statusCode, rec.Code, testCase.description, "status code")
+		assertion.Equalf(testCase.expect.isCalled, callChecker.IsCalled, testCase.description, "isCalled")
+	}
+}


### PR DESCRIPTION
認証が抜けており、本来見れてはいけない回答をエンドポイント直叩きで見ることができていた問題の修正。
Close #620 