### PR TITLE
masterマージ時のarm用image作成停止

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
           context: .
           push: true
           file: ./docker/staging/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
ちょっと気になって計算してみたところ今のペースで使っていると月あたりこのworkflowだけで400~500分使うペース。
traPtitechの無料枠で使えるのが2000分なことを考えると使い過ぎなのでmasterマージ時のarm用buildを停止する。