### PR TITLE
GET /responses/responseIDの認証修正

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -31,7 +31,7 @@ jobs:
           context: .
           push: true
           file: ./docker/staging/Dockerfile
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64
           tags: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:${{ env.IMAGE_TAG }}
           cache-from: type=gha
           cache-to: type=gha,mode=max

--- a/model/questionnaires_impl.go
+++ b/model/questionnaires_impl.go
@@ -377,7 +377,7 @@ func (*Questionnaire) GetResponseReadPrivilegeInfoByResponseID(userID string, re
 		Joins("INNER JOIN questionnaires ON questionnaires.id = respondents.questionnaire_id").
 		Joins("LEFT OUTER JOIN administrators ON questionnaires.id = administrators.questionnaire_id AND administrators.user_traqid = ?", userID).
 		Joins("LEFT OUTER JOIN respondents AS respondents2 ON questionnaires.id = respondents2.questionnaire_id AND respondents2.user_traqid = ? AND respondents2.submitted_at IS NOT NULL", userID).
-		Select("questionnaires.res_shared_to, administrators.questionnaire_id IS NULL AS is_administrator, respondents2.response_id IS NULL AS is_respondent").
+		Select("questionnaires.res_shared_to, administrators.questionnaire_id IS NOT NULL AS is_administrator, respondents2.response_id IS NOT NULL AS is_respondent").
 		Scan(&responseReadPrivilegeInfo).Error
 	if gorm.IsRecordNotFoundError(err) {
 		return nil, ErrInvalidResponseID


### PR DESCRIPTION
以下のリリース。
- GET /responses/responseIDの認証が抜けていた問題修正
    - #625 でリリースしたものではバグがあり、修正できていなかった