### PR TITLE
Spectralのエラー修正

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -316,6 +316,7 @@ paths:
       parameters:
         - $ref: '#/components/parameters/sortInQuery'
         - $ref: '#/components/parameters/answeredInQuery'
+        - $ref: '#/components/parameters/traQIDInPath'
       responses:
         '200':
           description: 正常に取得できました。アンケートの配列を返します。
@@ -444,6 +445,14 @@ components:
       required: true
       description: |
         回答ID
+      schema:
+        type: integer
+    traQIDInPath:
+      name: traQID
+      in: path
+      required: true
+      description: |
+        traQ ID(ex:mazrean)
       schema:
         type: integer
   schemas:

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -382,10 +382,9 @@ components:
     answeredInQuery:
       name: answered
       in: query
-      required: true
       description: 回答したもの(answered)か未回答のもの(unanswered)かを選別
       schema:
-        type: string
+        $ref: '#/components/schemas/AnsweredType'
     sortInQuery:
       name: sort
       in: query
@@ -456,6 +455,15 @@ components:
       schema:
         type: integer
   schemas:
+    AnsweredType:
+      type: string
+      description: アンケート検索時に回答済みかの状態での絞り込み
+      enum:
+        - answered
+        - unanswered
+      x-enum-varnames:
+        - Answered
+        - Unanswered
     SortType:
       type: string
       description: question、questionnaire用のソートの種類

--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -315,7 +315,7 @@ paths:
       description: ユーザが対象になっているアンケートのリストを取得します。
       parameters:
         - $ref: '#/components/parameters/sortInQuery'
-        - $ref: '#/components/parameters/answered'
+        - $ref: '#/components/parameters/answeredInQuery'
       responses:
         '200':
           description: 正常に取得できました。アンケートの配列を返します。
@@ -378,7 +378,7 @@ paths:
           description: 結果を閲覧する権限がありません。
 components:
   parameters:
-    answered:
+    answeredInQuery:
       name: answered
       in: query
       required: true


### PR DESCRIPTION
どこかでSpectralのチェックをすり抜けたようで、masterでSpectralがエラーを吐くようになっていたので修正。
また、クエリパラメーター`answered`が今までの命名規則から外れているのと、enumであるべきなのになっていないことに気がついたので修正。