### PR TITLE
traP部員かの認証修正

### DIFF
--- a/router.go
+++ b/router.go
@@ -33,7 +33,7 @@ func SetRouting(port string) {
 	e.File("/favicon.ico", "client/dist/favicon.ico")
 	e.File("*", "client/dist/index.html")
 
-	echoAPI := e.Group("/api", api.UserAuthenticate, api.SetValidatorMiddleware)
+	echoAPI := e.Group("/api", api.SetValidatorMiddleware, api.SetUserIDMiddleware, api.TraPMemberAuthenticate)
 	{
 		apiQuestionnnaires := echoAPI.Group("/questionnaires")
 		{

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -82,25 +82,6 @@ func (*Middleware) TraPMemberAuthenticate(next echo.HandlerFunc) echo.HandlerFun
 	}
 }
 
-// UserAuthenticate traPのメンバーかの認証
-func (*Middleware) UserAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
-	return func(c echo.Context) error {
-		userID := c.Request().Header.Get("X-Showcase-User")
-		if userID == "" {
-			userID = "mds_boy"
-		}
-
-		// トークンを持たないユーザはアクセスできない
-		if userID == "-" {
-			return echo.NewHTTPError(http.StatusUnauthorized, "You are not logged in")
-		}
-
-		c.Set(userIDKey, userID)
-
-		return next(c)
-	}
-}
-
 // QuestionnaireAdministratorAuthenticate アンケートの管理者かどうかの認証
 func (m *Middleware) QuestionnaireAdministratorAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -64,6 +64,24 @@ func (*Middleware) SetUserIDMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
 	}
 }
 
+// TraPMemberAuthenticate traP部員かの認証
+func (*Middleware) TraPMemberAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		userID, err := getUserID(c)
+		if err != nil {
+			c.Logger().Error(err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get userID: %w", err))
+		}
+
+		// トークンを持たないユーザはアクセスできない
+		if userID == "-" {
+			return echo.NewHTTPError(http.StatusUnauthorized, "You are not logged in")
+		}
+
+		return next(c)
+	}
+}
+
 // UserAuthenticate traPのメンバーかの認証
 func (*Middleware) UserAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -50,6 +50,20 @@ func (*Middleware) SetValidatorMiddleware(next echo.HandlerFunc) echo.HandlerFun
 暫定的にハードコーディングで対応*/
 var adminUserIDs = []string{"temma", "sappi_red", "ryoha", "mazrean", "YumizSui", "pure_white_404"}
 
+// SetUserIDMiddleware X-Showcase-UserからユーザーIDを取得しセットする
+func (*Middleware) SetUserIDMiddleware(next echo.HandlerFunc) echo.HandlerFunc {
+	return func(c echo.Context) error {
+		userID := c.Request().Header.Get("X-Showcase-User")
+		if userID == "" {
+			userID = "mds_boy"
+		}
+
+		c.Set(userIDKey, userID)
+
+		return next(c)
+	}
+}
+
 // UserAuthenticate traPのメンバーかの認証
 func (*Middleware) UserAuthenticate(next echo.HandlerFunc) echo.HandlerFunc {
 	return func(c echo.Context) error {

--- a/router/responses_test.go
+++ b/router/responses_test.go
@@ -506,7 +506,7 @@ func TestPostResponse(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.POST("/api/responses", r.PostResponse, m.UserAuthenticate)
+	e.POST("/api/responses", r.PostResponse, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		requestByte, jsonErr := json.Marshal(testCase.request.requestBody)
@@ -674,7 +674,7 @@ func TestGetResponse(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("/api/responses/:responseID", r.GetResponse, m.UserAuthenticate)
+	e.GET("/api/responses/:responseID", r.GetResponse, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 
@@ -1211,7 +1211,7 @@ func TestEditResponse(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.PATCH("/api/responses/:responseID", r.EditResponse, m.UserAuthenticate, m.RespondentAuthenticate)
+	e.PATCH("/api/responses/:responseID", r.EditResponse, m.SetUserIDMiddleware, m.TraPMemberAuthenticate, m.RespondentAuthenticate)
 
 	for _, testCase := range testCases {
 		requestByte, jsonErr := json.Marshal(testCase.request.requestBody)

--- a/router/users_test.go
+++ b/router/users_test.go
@@ -102,7 +102,7 @@ func TestGetUsersMe(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("api/users/me", u.GetUsersMe, m.UserAuthenticate)
+	e.GET("api/users/me", u.GetUsersMe, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		rec := createRecorder(e, testCase.request.user, methodGet, makePath("/users/me"), typeNone, "")
@@ -279,7 +279,7 @@ func TestGetMyResponses(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("api/users/me/responses", u.GetMyResponses, m.UserAuthenticate)
+	e.GET("api/users/me/responses", u.GetMyResponses, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		rec := createRecorder(e, testCase.request.user, methodGet, makePath("/users/me/responses"), typeNone, "")
@@ -453,7 +453,7 @@ func TestGetMyResponsesByID(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("api/users/me/responses/:questionnaireID", u.GetMyResponsesByID, m.UserAuthenticate)
+	e.GET("api/users/me/responses/:questionnaireID", u.GetMyResponsesByID, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		reqPath := fmt.Sprint(rootPath, "/users/me/responses/", testCase.request.questionnaireID)
@@ -602,7 +602,7 @@ func TestGetTargetedQuestionnaire(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("api/users/me/targeted", u.GetTargetedQuestionnaire, m.UserAuthenticate)
+	e.GET("api/users/me/targeted", u.GetTargetedQuestionnaire, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		rec := createRecorder(e, testCase.request.user, methodGet, makePath("/users/me/targeted"), typeNone, "")
@@ -751,7 +751,7 @@ func TestGetTargettedQuestionnairesBytraQID(t *testing.T) {
 	}
 
 	e := echo.New()
-	e.GET("api/users/:traQID/targeted", u.GetTargettedQuestionnairesBytraQID, m.UserAuthenticate)
+	e.GET("api/users/:traQID/targeted", u.GetTargettedQuestionnairesBytraQID, m.SetUserIDMiddleware, m.TraPMemberAuthenticate)
 
 	for _, testCase := range testCases {
 		rec := createRecorder(e, testCase.request.user, methodGet, fmt.Sprint(rootPath, "/users/", testCase.request.targetUser, "/targeted"), typeNone, "")


### PR DESCRIPTION
これまでUserAuthenticate1つで行っていたものをSetUserIDMiddlewareでtraP ID取り出し、TraPMemberAuthenticateで認証を行うようにした。
traP外の人が回答できるアンケート対応のため。
ref #618 