### PR TITLE
transactionの基盤作成

### DIFF
--- a/model/errors.go
+++ b/model/errors.go
@@ -25,4 +25,6 @@ var (
 	ErrTextMatching = errors.New("failed to match the pattern")
 	// ErrInvalidAnsweredParam invalid sort param
 	ErrInvalidAnsweredParam = errors.New("invalid answered param")
+	// ErrInvalidTx transactionに誤った値が入っている
+	ErrInvalidTx = errors.New("invalid tx")
 )

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -1,0 +1,8 @@
+package model
+
+import "context"
+
+// ITransaction Transaction処理のinterface
+type ITransaction interface {
+	Do(context.Context, func(context.Context) error) error
+}

--- a/model/transaction.go
+++ b/model/transaction.go
@@ -1,8 +1,11 @@
 package model
 
-import "context"
+import (
+	"context"
+	"database/sql"
+)
 
 // ITransaction Transaction処理のinterface
 type ITransaction interface {
-	Do(context.Context, func(context.Context) error) error
+	Do(context.Context, *sql.TxOptions, func(context.Context) error) error
 }

--- a/model/transaction_impl.go
+++ b/model/transaction_impl.go
@@ -1,0 +1,53 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+
+	"github.com/jinzhu/gorm"
+)
+
+type ctxKey string
+
+const (
+	txKey ctxKey = "transaction"
+)
+
+// Transaction ITransactionの実装
+type Transaction struct{}
+
+// Do トランザクション用の関数
+func (*Transaction) Do(ctx context.Context, txOption *sql.TxOptions, f func(ctx context.Context) error) error {
+	tx := db.BeginTx(ctx, txOption)
+
+	ctx = context.WithValue(ctx, txKey, tx)
+
+	err := f(ctx)
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed in transaction: %w", err)
+	}
+
+	err = tx.Commit().Error
+	if err != nil {
+		tx.Rollback()
+		return fmt.Errorf("failed to commit: %w", err)
+	}
+
+	return nil
+}
+
+func getTx(ctx context.Context) (*gorm.DB, error) {
+	iDB := ctx.Value(txKey)
+	if iDB == nil {
+		return db, nil
+	}
+
+	db, ok := iDB.(*gorm.DB)
+	if !ok {
+		return nil, ErrInvalidTx
+	}
+
+	return db, nil
+}

--- a/model/transaction_impl.go
+++ b/model/transaction_impl.go
@@ -17,6 +17,10 @@ const (
 // Transaction ITransactionの実装
 type Transaction struct{}
 
+func NewTransaction() *Transaction {
+	return &Transaction{}
+}
+
 // Do トランザクション用の関数
 func (*Transaction) Do(ctx context.Context, txOption *sql.TxOptions, f func(ctx context.Context) error) error {
 	tx := db.BeginTx(ctx, txOption)


### PR DESCRIPTION
contextにtransactionを取ったDBを設定し、`getTx`で取得することでgormへの依存を切りつつトランザクションを取れるようにした。
仕組み上context.Contextの伝搬が必須なので、 #632 ができないと使い物にならない。
ref #461 