### PR TITLE
ReDoS対策のタイムアウト

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -41,6 +41,8 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/QuestionnairesWithPageMax'
+        '408':
+          description: SQLの実行時間が3sを超えた場合。主に正規表現が原因。
     post:
       operationId: postQuestionnaire
       tags:

--- a/model/errors.go
+++ b/model/errors.go
@@ -27,4 +27,6 @@ var (
 	ErrInvalidAnsweredParam = errors.New("invalid answered param")
 	// ErrInvalidTx transactionに誤った値が入っている
 	ErrInvalidTx = errors.New("invalid tx")
+	// ErrDeadlineExceeded deadline exceeded
+	ErrDeadlineExceeded = errors.New("deadline exceeded")
 )

--- a/model/questionnaires_impl.go
+++ b/model/questionnaires_impl.go
@@ -197,6 +197,9 @@ func (*Questionnaire) GetQuestionnaires(userID string, sort string, search strin
 		Session(&gorm.Session{}).
 		Group("questionnaires.id").
 		Count(&count).Error
+	if errors.Is(err, context.DeadlineExceeded) {
+		return nil, 0, ErrDeadlineExceeded
+	}
 	if err != nil {
 		return nil, 0, fmt.Errorf("failed to retrieve the number of questionnaires: %w", err)
 	}
@@ -218,7 +221,10 @@ func (*Questionnaire) GetQuestionnaires(userID string, sort string, search strin
 		Group("questionnaires.id").
 		Select("questionnaires.*, (targets.user_traqid = ? OR targets.user_traqid = 'traP') AS is_targeted", userID).
 		Find(&questionnaires).Error
-	if err != nil && !errors.Is(err, gorm.ErrRecordNotFound) {
+	if errors.Is(err, context.DeadlineExceeded) {
+		return nil, 0, ErrDeadlineExceeded
+	}
+	if err != nil {
 		return nil, 0, fmt.Errorf("failed to get the targeted questionnaires: %w", err)
 	}
 

--- a/model/questionnaires_impl.go
+++ b/model/questionnaires_impl.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"regexp"
@@ -161,8 +162,14 @@ func (*Questionnaire) DeleteQuestionnaire(questionnaireID int) error {
 func (*Questionnaire) GetQuestionnaires(userID string, sort string, search string, pageNum int, nontargeted bool) ([]QuestionnaireInfo, int, error) {
 	questionnaires := make([]QuestionnaireInfo, 0, 20)
 
+	ctx, cancel := context.WithTimeout(context.Background(), 3*time.Second)
+	defer cancel()
+
 	query := db.
-		Session(&gorm.Session{NewDB: true}).
+		Session(&gorm.Session{
+			NewDB: true,
+			Context: ctx,
+		}).
 		Table("questionnaires").
 		Joins("LEFT OUTER JOIN targets ON questionnaires.id = targets.questionnaire_id")
 

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -75,6 +75,9 @@ func (q *Questionnaire) GetQuestionnaires(c echo.Context) error {
 		if errors.Is(err, model.ErrTooLargePageNum) || errors.Is(err, model.ErrInvalidRegex) {
 			return echo.NewHTTPError(http.StatusBadRequest, err)
 		}
+		if errors.Is(err, model.ErrDeadlineExceeded) {
+			return echo.NewHTTPError(http.StatusRequestTimeout, err)
+		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 


### PR DESCRIPTION
GORM 2.0に書き換えるときにうっかり消してしまっていたので修正。
ついでにタイムアウト時に500ではなく408を返すようにしたりもしている。