### PR TITLE
タイムアウト時のステータスコードを503に

### DIFF
--- a/docs/swagger/swagger.yaml
+++ b/docs/swagger/swagger.yaml
@@ -41,7 +41,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/QuestionnairesWithPageMax'
-        '408':
+        '503':
           description: SQLの実行時間が3sを超えた場合。主に正規表現が原因。
     post:
       operationId: postQuestionnaire

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -76,7 +76,7 @@ func (q *Questionnaire) GetQuestionnaires(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusBadRequest, err)
 		}
 		if errors.Is(err, model.ErrDeadlineExceeded) {
-			return echo.NewHTTPError(http.StatusRequestTimeout, err)
+			return echo.NewHTTPError(http.StatusServiceUnavailable, "deadline exceeded")
 		}
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}


### PR DESCRIPTION
408は4xxなのでクライアント側原因の時のエラー。
5xxを返すべきなので一番それっぽい気がする503 Service Unavailableにした。