### PR TITLE
model/questionnairesのcontext対応

### DIFF
--- a/model/questionnaires.go
+++ b/model/questionnaires.go
@@ -2,19 +2,23 @@
 
 package model
 
-import "gopkg.in/guregu/null.v3"
+import (
+	"context"
+
+	"gopkg.in/guregu/null.v3"
+)
 
 // IQuestionnaire QuestionnaireのRepository
 type IQuestionnaire interface {
-	InsertQuestionnaire(title string, description string, resTimeLimit null.Time, resSharedTo string) (int, error)
-	UpdateQuestionnaire(title string, description string, resTimeLimit null.Time, resSharedTo string, questionnaireID int) error
-	DeleteQuestionnaire(questionnaireID int) error
-	GetQuestionnaires(userID string, sort string, search string, pageNum int, nontargeted bool) ([]QuestionnaireInfo, int, error)
-	GetAdminQuestionnaires(userID string) ([]Questionnaires, error)
-	GetQuestionnaireInfo(questionnaireID int) (*Questionnaires, []string, []string, []string, error)
-	GetTargettedQuestionnaires(userID string, answered string, sort string) ([]TargettedQuestionnaire, error)
-	GetQuestionnaireLimit(questionnaireID int) (null.Time, error)
-	GetQuestionnaireLimitByResponseID(responseID int) (null.Time, error)
-	GetResponseReadPrivilegeInfoByResponseID(userID string, responseID int) (*ResponseReadPrivilegeInfo, error)
-	GetResponseReadPrivilegeInfoByQuestionnaireID(userID string, questionnaireID int) (*ResponseReadPrivilegeInfo, error)
+	InsertQuestionnaire(ctx context.Context, title string, description string, resTimeLimit null.Time, resSharedTo string) (int, error)
+	UpdateQuestionnaire(ctx context.Context, title string, description string, resTimeLimit null.Time, resSharedTo string, questionnaireID int) error
+	DeleteQuestionnaire(ctx context.Context, questionnaireID int) error
+	GetQuestionnaires(ctx context.Context, userID string, sort string, search string, pageNum int, nontargeted bool) ([]QuestionnaireInfo, int, error)
+	GetAdminQuestionnaires(ctx context.Context, userID string) ([]Questionnaires, error)
+	GetQuestionnaireInfo(ctx context.Context, questionnaireID int) (*Questionnaires, []string, []string, []string, error)
+	GetTargettedQuestionnaires(ctx context.Context, userID string, answered string, sort string) ([]TargettedQuestionnaire, error)
+	GetQuestionnaireLimit(ctx context.Context, questionnaireID int) (null.Time, error)
+	GetQuestionnaireLimitByResponseID(ctx context.Context, responseID int) (null.Time, error)
+	GetResponseReadPrivilegeInfoByResponseID(ctx context.Context, userID string, responseID int) (*ResponseReadPrivilegeInfo, error)
+	GetResponseReadPrivilegeInfoByQuestionnaireID(ctx context.Context, userID string, questionnaireID int) (*ResponseReadPrivilegeInfo, error)
 }

--- a/model/questionnaires_test.go
+++ b/model/questionnaires_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"math"
 	"sort"
@@ -448,7 +449,9 @@ func insertQuestionnaireTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaireID, err := questionnaireImpl.InsertQuestionnaire(testCase.args.title, testCase.args.description, testCase.args.resTimeLimit, testCase.args.resSharedTo)
+		ctx := context.Background()
+
+		questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, testCase.args.title, testCase.args.description, testCase.args.resTimeLimit, testCase.args.resSharedTo)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -641,6 +644,8 @@ func updateQuestionnaireTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		ctx := context.Background()
+
 		before := &testCase.before
 		questionnaire := Questionnaires{
 			Title:        before.title,
@@ -658,7 +663,7 @@ func updateQuestionnaireTest(t *testing.T) {
 		createdAt := questionnaire.CreatedAt
 		questionnaireID := questionnaire.ID
 		after := &testCase.after
-		err = questionnaireImpl.UpdateQuestionnaire(after.title, after.description, after.resTimeLimit, after.resSharedTo, questionnaireID)
+		err = questionnaireImpl.UpdateQuestionnaire(ctx, after.title, after.description, after.resTimeLimit, after.resSharedTo, questionnaireID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -720,7 +725,9 @@ func updateQuestionnaireTest(t *testing.T) {
 	}
 
 	for _, arg := range invalidTestCases {
-		err := questionnaireImpl.UpdateQuestionnaire(arg.title, arg.description, arg.resTimeLimit, arg.resSharedTo, invalidQuestionnaireID)
+		ctx := context.Background()
+
+		err := questionnaireImpl.UpdateQuestionnaire(ctx, arg.title, arg.description, arg.resTimeLimit, arg.resSharedTo, invalidQuestionnaireID)
 		if !errors.Is(err, ErrNoRecordUpdated) {
 			if err == nil {
 				t.Errorf("Succeeded with invalid questionnaireID")
@@ -764,6 +771,8 @@ func deleteQuestionnaireTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
+		ctx := context.Background()
+
 		questionnaire := Questionnaires{
 			Title:        testCase.args.title,
 			Description:  testCase.args.description,
@@ -778,7 +787,7 @@ func deleteQuestionnaireTest(t *testing.T) {
 		}
 
 		questionnaireID := questionnaire.ID
-		err = questionnaireImpl.DeleteQuestionnaire(questionnaireID)
+		err = questionnaireImpl.DeleteQuestionnaire(ctx, questionnaireID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -820,7 +829,9 @@ func deleteQuestionnaireTest(t *testing.T) {
 		invalidQuestionnaireID *= 10
 	}
 
-	err := questionnaireImpl.DeleteQuestionnaire(invalidQuestionnaireID)
+	ctx := context.Background()
+
+	err := questionnaireImpl.DeleteQuestionnaire(ctx, invalidQuestionnaireID)
 	if !errors.Is(err, ErrNoRecordDeleted) {
 		if err == nil {
 			t.Errorf("Succeeded with invalid questionnaireID")
@@ -1042,7 +1053,9 @@ func getQuestionnairesTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaires, pageMax, err := questionnaireImpl.GetQuestionnaires(testCase.args.userID, testCase.args.sort, testCase.args.search, testCase.args.pageNum, testCase.args.nontargeted)
+		ctx := context.Background()
+
+		questionnaires, pageMax, err := questionnaireImpl.GetQuestionnaires(ctx, testCase.args.userID, testCase.args.sort, testCase.args.search, testCase.args.pageNum, testCase.args.nontargeted)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1143,7 +1156,9 @@ func getAdminQuestionnairesTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaires, err := questionnaireImpl.GetAdminQuestionnaires(testCase.userID)
+		ctx := context.Background()
+
+		questionnaires, err := questionnaireImpl.GetAdminQuestionnaires(ctx, testCase.userID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1300,7 +1315,9 @@ func getQuestionnaireInfoTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualQuestionnaire, actualTargets, actualAdministrators, actualRespondents, err := questionnaireImpl.GetQuestionnaireInfo(testCase.questionnaireID)
+		ctx := context.Background()
+
+		actualQuestionnaire, actualTargets, actualAdministrators, actualRespondents, err := questionnaireImpl.GetQuestionnaireInfo(ctx, testCase.questionnaireID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1482,7 +1499,9 @@ func getTargettedQuestionnairesTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaires, err := questionnaireImpl.GetTargettedQuestionnaires(testCase.args.userID, testCase.args.answered, testCase.args.sort)
+		ctx := context.Background()
+
+		questionnaires, err := questionnaireImpl.GetTargettedQuestionnaires(ctx, testCase.args.userID, testCase.args.answered, testCase.args.sort)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1601,7 +1620,9 @@ func getQuestionnaireLimitTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualLimit, err := questionnaireImpl.GetQuestionnaireLimit(testCase.args.questionnaireID)
+		ctx := context.Background()
+
+		actualLimit, err := questionnaireImpl.GetQuestionnaireLimit(ctx, testCase.args.questionnaireID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1686,7 +1707,9 @@ func getQuestionnaireLimitByResponseIDTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		actualLimit, err := questionnaireImpl.GetQuestionnaireLimitByResponseID(testCase.args.responseID)
+		ctx := context.Background()
+
+		actualLimit, err := questionnaireImpl.GetQuestionnaireLimitByResponseID(ctx, testCase.args.responseID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -1857,7 +1880,9 @@ func getResponseReadPrivilegeInfoByResponseIDTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		responseReadPrivilegeInfo, err := questionnaireImpl.GetResponseReadPrivilegeInfoByResponseID(testCase.args.userID, testCase.args.responseID)
+		ctx := context.Background()
+
+		responseReadPrivilegeInfo, err := questionnaireImpl.GetResponseReadPrivilegeInfoByResponseID(ctx, testCase.args.userID, testCase.args.responseID)
 
 		if testCase.expect.isErr {
 			if testCase.expect.err == nil {
@@ -1998,7 +2023,9 @@ func getResponseReadPrivilegeInfoByQuestionnaireIDTest(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		responseReadPrivilegeInfo, err := questionnaireImpl.GetResponseReadPrivilegeInfoByQuestionnaireID(testCase.args.userID, testCase.args.questionnaireID)
+		ctx := context.Background()
+
+		responseReadPrivilegeInfo, err := questionnaireImpl.GetResponseReadPrivilegeInfoByQuestionnaireID(ctx, testCase.args.userID, testCase.args.questionnaireID)
 
 		if testCase.expect.isErr {
 			if testCase.expect.err == nil {

--- a/model/respondents_test.go
+++ b/model/respondents_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -16,8 +17,9 @@ func TestInsertRespondent(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -125,8 +127,9 @@ func TestUpdateSubmittedAt(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -198,8 +201,9 @@ func TestDeleteRespondent(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -288,6 +292,7 @@ func TestDeleteRespondent(t *testing.T) {
 func TestGetRespondentInfos(t *testing.T) {
 	t.Parallel()
 	assertion := assert.New(t)
+	ctx := context.Background()
 
 	type args struct {
 		questionnaireIDs []int
@@ -303,9 +308,9 @@ func TestGetRespondentInfos(t *testing.T) {
 		args
 		expect
 	}
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第2回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第2回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
-	questionnaireID2, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第2回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID2, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第2回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	questionnaire := Questionnaires{}
@@ -432,8 +437,9 @@ func TestGetRespondentDetail(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	questionnaire := Questionnaires{}
@@ -528,8 +534,9 @@ func TestGetRespondentDetails(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	questionnaire := Questionnaires{}
@@ -790,6 +797,7 @@ func TestGetRespondentDetails(t *testing.T) {
 func TestGetRespondentsUserIDs(t *testing.T) {
 	t.Parallel()
 	assertion := assert.New(t)
+	ctx := context.Background()
 
 	type args struct {
 		questionnaireIDs []int
@@ -807,7 +815,7 @@ func TestGetRespondentsUserIDs(t *testing.T) {
 	}
 	questionnaireIDs := make([]int, 0, 3)
 	for i := 0; i < 3; i++ {
-		questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+		questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 		require.NoError(t, err)
 		questionnaireIDs = append(questionnaireIDs, questionnaireID)
 	}
@@ -893,8 +901,9 @@ func TestTestCheckRespondent(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -973,8 +982,9 @@ func TestCheckRespondentByResponseID(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})

--- a/model/responses_test.go
+++ b/model/responses_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -16,8 +17,9 @@ func TestInsertResponses(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -138,8 +140,9 @@ func TestDeleteResponse(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})

--- a/model/scale_labels_test.go
+++ b/model/scale_labels_test.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"math"
 	"strings"
@@ -17,8 +18,9 @@ func TestInsertScaleLabel(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -159,8 +161,9 @@ func TestUpdateScaleLabel(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -278,8 +281,9 @@ func TestDeleteScaleLabel(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -365,8 +369,9 @@ func TestDeleteScaleLabel(t *testing.T) {
 func TestGetScaleLabels(t *testing.T) {
 	t.Parallel()
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -482,8 +487,9 @@ func TestCheckScaleLabel(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})

--- a/model/validations_test.go
+++ b/model/validations_test.go
@@ -2,6 +2,7 @@
 package model
 
 import (
+	"context"
 	"errors"
 	"strings"
 	"testing"
@@ -17,8 +18,9 @@ func TestInsertValidation(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -208,8 +210,9 @@ func TestUpdateValidation(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -355,8 +358,9 @@ func TestDeleteValidation(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
@@ -452,8 +456,9 @@ func TestGetValidations(t *testing.T) {
 	t.Parallel()
 
 	assertion := assert.New(t)
+	ctx := context.Background()
 
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire("第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
+	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "public")
 	require.NoError(t, err)
 
 	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -164,7 +164,7 @@ func (m *Middleware) ResponseReadAuthenticate(next echo.HandlerFunc) echo.Handle
 			return next(c)
 		}
 
-		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByResponseID(userID, responseID)
+		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByResponseID(c.Request().Context(), userID, responseID)
 		if errors.Is(err, model.ErrRecordNotFound) {
 			c.Logger().Info(err)
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid responseID: %d", responseID))
@@ -271,7 +271,7 @@ func (m *Middleware) ResultAuthenticate(next echo.HandlerFunc) echo.HandlerFunc 
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid questionnaireID:%s(error: %w)", strQuestionnaireID, err))
 		}
 
-		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByQuestionnaireID(userID, questionnaireID)
+		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByQuestionnaireID(c.Request().Context(), userID, questionnaireID)
 		if errors.Is(err, model.ErrRecordNotFound) {
 			c.Logger().Info(err)
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Sprintf("invalid responseID: %d", questionnaireID))

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -298,17 +298,6 @@ func TestResponseReadAuthenticate(t *testing.T) {
 			}
 		}
 
-		mockRespondent.
-			EXPECT().
-			CheckRespondentByResponseID(userID, responseID).
-			Return(testCase.args.isRespondent, testCase.args.CheckRespondentByResponseIDError)
-		if !testCase.args.isRespondent && testCase.args.CheckRespondentByResponseIDError == nil {
-			mockQuestionnaire.
-				EXPECT().
-				GetResponseReadPrivilegeInfoByResponseID(userID, responseID).
-				Return(&responseReadPrivilegeInfo, testCase.args.GetResponseReadPrivilegeInfoByResponseIDError)
-		}
-
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, "/", nil)
 		rec := httptest.NewRecorder()
@@ -317,6 +306,17 @@ func TestResponseReadAuthenticate(t *testing.T) {
 		c.SetParamNames("responseID")
 		c.SetParamValues(strconv.Itoa(responseID))
 		c.Set(userIDKey, userID)
+
+		mockRespondent.
+			EXPECT().
+			CheckRespondentByResponseID(userID, responseID).
+			Return(testCase.args.isRespondent, testCase.args.CheckRespondentByResponseIDError)
+		if !testCase.args.isRespondent && testCase.args.CheckRespondentByResponseIDError == nil {
+			mockQuestionnaire.
+				EXPECT().
+				GetResponseReadPrivilegeInfoByResponseID(c.Request().Context(), userID, responseID).
+				Return(&responseReadPrivilegeInfo, testCase.args.GetResponseReadPrivilegeInfoByResponseIDError)
+		}
 
 		callChecker := CallChecker{}
 
@@ -431,11 +431,6 @@ func TestResultAuthenticate(t *testing.T) {
 			}
 		}
 
-		mockQuestionnaire.
-			EXPECT().
-			GetResponseReadPrivilegeInfoByQuestionnaireID(userID, questionnaireID).
-			Return(&responseReadPrivilegeInfo, testCase.args.GetResponseReadPrivilegeInfoByResponseIDError)
-
 		e := echo.New()
 		req := httptest.NewRequest(http.MethodGet, fmt.Sprintf("/results/%d", questionnaireID), nil)
 		rec := httptest.NewRecorder()
@@ -444,6 +439,11 @@ func TestResultAuthenticate(t *testing.T) {
 		c.SetParamNames("questionnaireID")
 		c.SetParamValues(strconv.Itoa(questionnaireID))
 		c.Set(userIDKey, userID)
+
+		mockQuestionnaire.
+			EXPECT().
+			GetResponseReadPrivilegeInfoByQuestionnaireID(c.Request().Context(), userID, questionnaireID).
+			Return(&responseReadPrivilegeInfo, testCase.args.GetResponseReadPrivilegeInfoByResponseIDError)
 
 		callChecker := CallChecker{}
 

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -70,7 +70,7 @@ func (q *Questionnaire) GetQuestionnaires(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("failed to convert the string query parameter 'nontargeted'(%s) to bool: %w", nontargeted, err))
 	}
 
-	questionnaires, pageMax, err := q.IQuestionnaire.GetQuestionnaires(userID, sort, search, pageNum, nontargetedBool)
+	questionnaires, pageMax, err := q.IQuestionnaire.GetQuestionnaires(c.Request().Context(), userID, sort, search, pageNum, nontargetedBool)
 	if err != nil {
 		if errors.Is(err, model.ErrTooLargePageNum) || errors.Is(err, model.ErrInvalidRegex) {
 			return echo.NewHTTPError(http.StatusBadRequest, err)
@@ -126,7 +126,7 @@ func (q *Questionnaire) PostQuestionnaire(c echo.Context) error {
 		}
 	}
 
-	lastID, err := q.InsertQuestionnaire(req.Title, req.Description, req.ResTimeLimit, req.ResSharedTo)
+	lastID, err := q.InsertQuestionnaire(c.Request().Context(), req.Title, req.Description, req.ResTimeLimit, req.ResSharedTo)
 	if err != nil {
 		return err
 	}
@@ -183,7 +183,7 @@ func (q *Questionnaire) GetQuestionnaire(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid questionnaireID:%s(error: %w)", strQuestionnaireID, err))
 	}
 
-	questionnaire, targets, administrators, respondents, err := q.GetQuestionnaireInfo(questionnaireID)
+	questionnaire, targets, administrators, respondents, err := q.GetQuestionnaireInfo(c.Request().Context(), questionnaireID)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
@@ -231,8 +231,8 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, err.Error())
 	}
 
-	if err := q.UpdateQuestionnaire(
-		req.Title, req.Description, req.ResTimeLimit, req.ResSharedTo, questionnaireID); err != nil {
+	err = q.UpdateQuestionnaire(c.Request().Context(), req.Title, req.Description, req.ResTimeLimit, req.ResSharedTo, questionnaireID)
+	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
@@ -262,7 +262,7 @@ func (q *Questionnaire) DeleteQuestionnaire(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaireID: %w", err))
 	}
 
-	if err := q.IQuestionnaire.DeleteQuestionnaire(questionnaireID); err != nil {
+	if err := q.IQuestionnaire.DeleteQuestionnaire(c.Request().Context(), questionnaireID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/router/responses.go
+++ b/router/responses.go
@@ -54,7 +54,7 @@ func (r *Response) PostResponse(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	limit, err := r.GetQuestionnaireLimit(req.ID)
+	limit, err := r.GetQuestionnaireLimit(c.Request().Context(), req.ID)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
@@ -208,7 +208,7 @@ func (r *Response) EditResponse(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest)
 	}
 
-	limit, err := r.GetQuestionnaireLimit(req.ID)
+	limit, err := r.GetQuestionnaireLimit(c.Request().Context(), req.ID)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {
 			return echo.NewHTTPError(http.StatusNotFound, err)
@@ -345,7 +345,7 @@ func (r *Response) DeleteResponse(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get responseID: %w", err))
 	}
 
-	limit, err := r.GetQuestionnaireLimitByResponseID(responseID)
+	limit, err := r.GetQuestionnaireLimitByResponseID(c.Request().Context(), responseID)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {
 			c.Logger().Info(err)

--- a/router/responses_test.go
+++ b/router/responses_test.go
@@ -103,15 +103,15 @@ func TestPostResponse(t *testing.T) {
 	// GetQuestionnaireLimit
 	// success
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDSuccess).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDSuccess).
 		Return(null.TimeFrom(nowTime.Add(time.Minute)), nil).AnyTimes()
 	// failure
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDFailure).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDFailure).
 		Return(null.NewTime(time.Time{}, false), model.ErrRecordNotFound).AnyTimes()
 	// limit
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDLimit).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDLimit).
 		Return(null.TimeFrom(nowTime.Add(-time.Minute)), nil).AnyTimes()
 
 	// Validation
@@ -767,15 +767,15 @@ func TestEditResponse(t *testing.T) {
 	// GetQuestionnaireLimit
 	// success
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDSuccess).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDSuccess).
 		Return(null.TimeFrom(nowTime.Add(time.Minute)), nil).AnyTimes()
 	// failure
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDFailure).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDFailure).
 		Return(null.NewTime(time.Time{}, false), errMock).AnyTimes()
 	// limit
 	mockQuestionnaire.EXPECT().
-		GetQuestionnaireLimit(questionnaireIDLimit).
+		GetQuestionnaireLimit(gomock.Any(), questionnaireIDLimit).
 		Return(null.TimeFrom(nowTime.Add(-time.Minute)), nil).AnyTimes()
 
 	// Validation
@@ -1353,7 +1353,7 @@ func TestDeleteResponse(t *testing.T) {
 
 		mockQuestionnaire.
 			EXPECT().
-			GetQuestionnaireLimitByResponseID(responseID).
+			GetQuestionnaireLimitByResponseID(gomock.Any(), responseID).
 			Return(testCase.request.QuestionnaireLimit, testCase.request.GetQuestionnaireLimitError)
 		if testCase.request.ExecutesDeletion {
 			mockRespondent.

--- a/router/users.go
+++ b/router/users.go
@@ -86,7 +86,7 @@ func (u *User) GetTargetedQuestionnaire(c echo.Context) error {
 	}
 
 	sort := c.QueryParam("sort")
-	ret, err := u.GetTargettedQuestionnaires(userID, "", sort)
+	ret, err := u.GetTargettedQuestionnaires(c.Request().Context(), userID, "", sort)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
@@ -102,7 +102,7 @@ func (u *User) GetMyQuestionnaire(c echo.Context) error {
 	}
 
 	// 自分が管理者になっているアンケート一覧
-	questionnaires, err := u.GetAdminQuestionnaires(userID)
+	questionnaires, err := u.GetAdminQuestionnaires(c.Request().Context(), userID)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaires: %w", err))
 	}
@@ -223,7 +223,7 @@ func (u *User) GetTargettedQuestionnairesBytraQID(c echo.Context) error {
 	traQID := c.Param("traQID")
 	sort := c.QueryParam("sort")
 	answered := c.QueryParam("answered")
-	ret, err := u.GetTargettedQuestionnaires(traQID, answered, sort)
+	ret, err := u.GetTargettedQuestionnaires(c.Request().Context(), traQID, answered, sort)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}

--- a/router/users_test.go
+++ b/router/users_test.go
@@ -545,15 +545,15 @@ func TestGetTargetedQuestionnaire(t *testing.T) {
 	// GetTargettedQuestionnaires
 	// success
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires(string(userOne), "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), string(userOne), "", gomock.Any()).
 		Return(targettedQuestionnaires, nil).AnyTimes()
 	// empty
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires("empty", "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), "empty", "", gomock.Any()).
 		Return([]model.TargettedQuestionnaire{}, nil).AnyTimes()
 	// failure
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires("StatusInternalServerError", "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), "StatusInternalServerError", "", gomock.Any()).
 		Return(nil, errMock).AnyTimes()
 
 	type request struct {
@@ -696,15 +696,15 @@ func TestGetTargettedQuestionnairesBytraQID(t *testing.T) {
 	// GetTargettedQuestionnaires
 	// success
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires(string(userOne), "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), string(userOne), "", gomock.Any()).
 		Return(targettedQuestionnaires, nil).AnyTimes()
 	// empty
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires("empty", "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), "empty", "", gomock.Any()).
 		Return([]model.TargettedQuestionnaire{}, nil).AnyTimes()
 	// failure
 	mockQuestionnaire.EXPECT().
-		GetTargettedQuestionnaires("StatusInternalServerError", "", gomock.Any()).
+		GetTargettedQuestionnaires(gomock.Any(), "StatusInternalServerError", "", gomock.Any()).
 		Return(nil, errMock).AnyTimes()
 
 	type request struct {


### PR DESCRIPTION
modelのquestionnaire周りをcontextに対応させた。
router側でトランザクション基盤利用でトランザクションを取ったものがquestionnaire周りには効くようになる。
ref #461 #632 