### PR TITLE
DeleteRespondentの役割縮小

### DIFF
--- a/model/respondents.go
+++ b/model/respondents.go
@@ -8,7 +8,7 @@ import "gopkg.in/guregu/null.v3"
 type IRespondent interface {
 	InsertRespondent(userID string, questionnaireID int, submitedAt null.Time) (int, error)
 	UpdateSubmittedAt(responseID int) error
-	DeleteRespondent(userID string, responseID int) error
+	DeleteRespondent(responseID int) error
 	GetRespondentInfos(userID string, questionnaireIDs ...int) ([]RespondentInfo, error)
 	GetRespondentDetail(responseID int) (RespondentDetail, error)
 	GetRespondentDetails(questionnaireID int, sort string) ([]RespondentDetail, error)

--- a/router/responses.go
+++ b/router/responses.go
@@ -333,12 +333,6 @@ func (r *Response) EditResponse(c echo.Context) error {
 
 // DeleteResponse DELETE /responses/:responseID
 func (r *Response) DeleteResponse(c echo.Context) error {
-	userID, err := getUserID(c)
-	if err != nil {
-		c.Logger().Error(err)
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get userID: %w", err))
-	}
-
 	responseID, err := getResponseID(c)
 	if err != nil {
 		c.Logger().Error(err)
@@ -361,7 +355,14 @@ func (r *Response) DeleteResponse(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusMethodNotAllowed)
 	}
 
-	if err := r.DeleteRespondent(userID, responseID); err != nil {
+	err = r.DeleteRespondent(responseID)
+	if err != nil {
+		c.Logger().Error(err)
+		return echo.NewHTTPError(http.StatusInternalServerError, err)
+	}
+
+	err = r.IResponse.DeleteResponse(responseID)
+	if err != nil {
 		c.Logger().Error(err)
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}

--- a/router/responses_test.go
+++ b/router/responses_test.go
@@ -1252,6 +1252,7 @@ func TestDeleteResponse(t *testing.T) {
 		GetQuestionnaireLimitError error
 		ExecutesDeletion           bool
 		DeleteRespondentError      error
+		DeleteResponseError        error
 	}
 	type expect struct {
 		statusCode int
@@ -1270,6 +1271,7 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: nil,
 				ExecutesDeletion:           true,
 				DeleteRespondentError:      nil,
+				DeleteResponseError:        nil,
 			},
 			expect: expect{
 				statusCode: http.StatusOK,
@@ -1282,6 +1284,7 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: nil,
 				ExecutesDeletion:           true,
 				DeleteRespondentError:      nil,
+				DeleteResponseError:        nil,
 			},
 			expect: expect{
 				statusCode: http.StatusOK,
@@ -1294,6 +1297,7 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: nil,
 				ExecutesDeletion:           false,
 				DeleteRespondentError:      nil,
+				DeleteResponseError:        nil,
 			},
 			expect: expect{
 				statusCode: http.StatusMethodNotAllowed,
@@ -1306,6 +1310,7 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: model.ErrRecordNotFound,
 				ExecutesDeletion:           false,
 				DeleteRespondentError:      nil,
+				DeleteResponseError:        nil,
 			},
 			expect: expect{
 				statusCode: http.StatusNotFound,
@@ -1318,6 +1323,7 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: errors.New("error"),
 				ExecutesDeletion:           false,
 				DeleteRespondentError:      nil,
+				DeleteResponseError:        nil,
 			},
 			expect: expect{
 				statusCode: http.StatusInternalServerError,
@@ -1330,6 +1336,20 @@ func TestDeleteResponse(t *testing.T) {
 				GetQuestionnaireLimitError: nil,
 				ExecutesDeletion:           true,
 				DeleteRespondentError:      errors.New("error"),
+				DeleteResponseError:        nil,
+			},
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			description: "DeleteResponseがエラーを吐くので500",
+			request: request{
+				QuestionnaireLimit:         null.NewTime(time.Time{}, false),
+				GetQuestionnaireLimitError: nil,
+				ExecutesDeletion:           true,
+				DeleteRespondentError:      nil,
+				DeleteResponseError:        errors.New("error"),
 			},
 			expect: expect{
 				statusCode: http.StatusInternalServerError,
@@ -1358,8 +1378,14 @@ func TestDeleteResponse(t *testing.T) {
 		if testCase.request.ExecutesDeletion {
 			mockRespondent.
 				EXPECT().
-				DeleteRespondent(userID, responseID).
+				DeleteRespondent(responseID).
 				Return(testCase.request.DeleteRespondentError)
+			if testCase.request.DeleteRespondentError == nil {
+				mockResponse.
+					EXPECT().
+					DeleteResponse(responseID).
+					Return(testCase.request.DeleteResponseError)
+			}
 		}
 
 		e.HTTPErrorHandler(r.DeleteResponse(c), c)


### PR DESCRIPTION
これまでDeleteRespondent内でrespondentだけでなくresponseの削除も行なっていた。
これはDeleteResponseでやるべき。

また、仕様上は回答の削除ができずmiddlewareでリクエストが弾かれるadministratorにも、DeleteRespondentでは削除が許可するように実装されていた。
仮にadministratorにも削除できるようにしたい場合でもmiddlewareの修正で対応するべき。

また、トランザクションを取るのはrouter側に統一したい。

これらを踏まえて、DeleteRespondentをただrespondentの削除をするだけに修正した。