### PR TITLE
resultに一時保存の回答が出ていた

### DIFF
--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -214,6 +214,7 @@ func (*Respondent) GetRespondentDetail(responseID int) (RespondentDetail, error)
 func (*Respondent) GetRespondentDetails(questionnaireID int, sort string) ([]RespondentDetail, error) {
 	respondents := []Respondents{}
 
+	// Note: respondents.submitted_at IS NOT NULLで一時保存の回答を除外している
 	query := db.
 		Session(&gorm.Session{NewDB: true}).
 		Where("respondents.questionnaire_id = ? AND respondents.submitted_at IS NOT NULL", questionnaireID).

--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -216,7 +216,7 @@ func (*Respondent) GetRespondentDetails(questionnaireID int, sort string) ([]Res
 
 	query := db.
 		Session(&gorm.Session{NewDB: true}).
-		Where("respondents.questionnaire_id = ?", questionnaireID).
+		Where("respondents.questionnaire_id = ? AND respondents.submitted_at IS NOT NULL", questionnaireID).
 		Select("ResponseID", "UserTraqid", "ModifiedAt", "SubmittedAt")
 
 	query, sortNum, err := setRespondentsOrder(query, sort)

--- a/model/respondents_test.go
+++ b/model/respondents_test.go
@@ -608,6 +608,11 @@ func TestGetRespondentDetails(t *testing.T) {
 			UserTraqid:      userThree,
 			SubmittedAt:     null.NewTime(time.Now().Add(time.Second*2), true),
 		},
+		{
+			QuestionnaireID: questionnaireID,
+			UserTraqid:      userOne,
+			SubmittedAt:     null.NewTime(time.Now(), false),
+		},
 	}
 
 	responseMetasList := [][]*ResponseMeta{
@@ -625,6 +630,11 @@ func TestGetRespondentDetails(t *testing.T) {
 			{QuestionID: questionIDs[0], Data: "リマインダーBOTを作った話3"},
 			{QuestionID: questionIDs[1], Data: "選択肢3"},
 			{QuestionID: questionIDs[2], Data: "0"},
+		},
+		{
+			{QuestionID: questionIDs[0], Data: "リマインダーBOTを作った話1"},
+			{QuestionID: questionIDs[1], Data: "選択肢1"},
+			{QuestionID: questionIDs[2], Data: "10"},
 		},
 	}
 


### PR DESCRIPTION
#636 でGetRespondentDetailsに`respondents.submitted_at IS NOT NULL`が抜けて、resultに一時保存の回答が混ざるようになっていた。
まだリリース前の変更なので本番環境では出ていない。
また、再発防止に一時保存の回答が混ざっていたらテストに落ちるようにした。