### PR TITLE
GET /responses/:responseIDで一時保存の回答を見えないように

### DIFF
--- a/model/respondents.go
+++ b/model/respondents.go
@@ -9,10 +9,10 @@ type IRespondent interface {
 	InsertRespondent(userID string, questionnaireID int, submitedAt null.Time) (int, error)
 	UpdateSubmittedAt(responseID int) error
 	DeleteRespondent(responseID int) error
+	GetRespondent(responseID int) (*Respondents, error)
 	GetRespondentInfos(userID string, questionnaireIDs ...int) ([]RespondentInfo, error)
 	GetRespondentDetail(responseID int) (RespondentDetail, error)
 	GetRespondentDetails(questionnaireID int, sort string) ([]RespondentDetail, error)
 	GetRespondentsUserIDs(questionnaireIDs []int) ([]Respondents, error)
 	CheckRespondent(userID string, questionnaireID int) (bool, error)
-	CheckRespondentByResponseID(userID string, responseID int) (bool, error)
 }

--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -119,6 +119,24 @@ func (*Respondent) DeleteRespondent(responseID int) error {
 	return nil
 }
 
+// CheckRespondentByResponseID 回答者かどうかの確認
+func (*Respondent) GetRespondent(responseID int) (*Respondents, error) {
+	var respondent Respondents
+
+	err := db.
+		Session(&gorm.Session{NewDB: true}).
+		Where("response_id = ?", responseID).
+		First(&respondent).Error
+	if errors.Is(err, gorm.ErrRecordNotFound) {
+		return nil, ErrRecordNotFound
+	}
+	if err != nil {
+		return nil, fmt.Errorf("failed to get response: %w", err)
+	}
+
+	return &respondent, nil
+}
+
 // GetRespondentInfos ユーザーの回答とその周辺情報一覧の取得
 func (*Respondent) GetRespondentInfos(userID string, questionnaireIDs ...int) ([]RespondentInfo, error) {
 	respondentInfos := []RespondentInfo{}
@@ -331,22 +349,6 @@ func (*Respondent) CheckRespondent(userID string, questionnaireID int) (bool, er
 	err := db.
 		Session(&gorm.Session{NewDB: true}).
 		Where("user_traqid = ? AND questionnaire_id = ?", userID, questionnaireID).
-		First(&Respondents{}).Error
-	if errors.Is(err, gorm.ErrRecordNotFound) {
-		return false, nil
-	}
-	if err != nil {
-		return false, fmt.Errorf("failed to get response: %w", err)
-	}
-
-	return true, nil
-}
-
-// CheckRespondentByResponseID 回答者かどうかの確認
-func (*Respondent) CheckRespondentByResponseID(userID string, responseID int) (bool, error) {
-	err := db.
-		Session(&gorm.Session{NewDB: true}).
-		Where("user_traqid = ? AND response_id = ?", userID, responseID).
 		First(&Respondents{}).Error
 	if errors.Is(err, gorm.ErrRecordNotFound) {
 		return false, nil

--- a/model/respondents_test.go
+++ b/model/respondents_test.go
@@ -355,7 +355,18 @@ func TestGetRespondent(t *testing.T) {
 			continue
 		}
 
-		assertion.Equal(testCase.expect.respondent, *actualRespondent, testCase.description, "respondent")
+		assertion.Equal(testCase.expect.respondent.ResponseID, actualRespondent.ResponseID, testCase.description, "responseID")
+		assertion.Equal(testCase.expect.respondent.QuestionnaireID, actualRespondent.QuestionnaireID, testCase.description, "questionnaireID")
+		assertion.Equal(testCase.expect.respondent.UserTraqid, actualRespondent.UserTraqid, testCase.description, "traQ ID")
+		assertion.Equal(testCase.expect.respondent.SubmittedAt.Valid, actualRespondent.SubmittedAt.Valid, testCase.description, "submittedAt valid")
+		if testCase.expect.respondent.SubmittedAt.Valid {
+			assertion.WithinDuration(testCase.expect.respondent.SubmittedAt.Time, actualRespondent.SubmittedAt.Time, 2*time.Second, testCase.description, "submittedAt")
+		}
+		assertion.WithinDuration(testCase.expect.respondent.ModifiedAt, actualRespondent.ModifiedAt, 2*time.Second, testCase.description, "modifiedAt")
+		assertion.Equal(testCase.expect.respondent.DeletedAt.Valid, actualRespondent.DeletedAt.Valid, testCase.description, "deletedAt valid")
+		if testCase.expect.respondent.DeletedAt.Valid {
+			assertion.WithinDuration(testCase.expect.respondent.DeletedAt.Time, actualRespondent.DeletedAt.Time, 2*time.Second, testCase.description, "deletedAt")
+		}
 	}
 }
 

--- a/model/respondents_test.go
+++ b/model/respondents_test.go
@@ -279,6 +279,86 @@ func TestDeleteRespondent(t *testing.T) {
 	}
 }
 
+func TestGetRespondent(t *testing.T) {
+	t.Parallel()
+
+	assertion := assert.New(t)
+
+	questionnaire := Questionnaires{
+		Title:       "第1回集会らん☆ぷろ募集アンケート",
+		Description: "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！",
+		ResTimeLimit: null.NewTime(time.Now(), false),
+		ResSharedTo: "private",
+	}
+	err := db.
+		Session(&gorm.Session{NewDB: true}).
+		Create(&questionnaire).Error
+	require.NoError(t, err)
+
+	respondent := Respondents{
+		UserTraqid: userOne,
+		QuestionnaireID: questionnaire.ID,
+		SubmittedAt: null.NewTime(time.Now(), true),
+	}
+	err = db.
+		Session(&gorm.Session{NewDB: true}).
+		Create(&respondent).Error
+	require.NoError(t, err)
+
+	type args struct {
+		responseID int
+	}
+	type expect struct {
+		respondent   Respondents
+		isErr        bool
+		err          error
+	}
+
+	type test struct {
+		description string
+		args
+		expect
+	}
+
+	testCases := []test{
+		{
+			description: "valid",
+			args: args{
+				responseID: respondent.ResponseID,
+			},
+			expect: expect{
+				respondent: respondent,
+			},
+		},
+		{
+			description: "questionnaireID does not exist",
+			args: args{
+				responseID: -1,
+			},
+			expect: expect{
+				isErr: true,
+				err:   ErrRecordNotFound,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		actualRespondent, err := respondentImpl.GetRespondent(testCase.args.responseID)
+		if !testCase.expect.isErr {
+			assertion.NoError(err, testCase.description, "no error")
+		} else if testCase.expect.err != nil {
+			assertion.Equal(true, errors.Is(err, testCase.expect.err), testCase.description, "errorIs")
+		} else if testCase.expect.isErr {
+			assertion.Error(err, testCase.description, "any error")
+		}
+		if err != nil {
+			continue
+		}
+
+		assertion.Equal(testCase.expect.respondent, *actualRespondent, testCase.description, "respondent")
+	}
+}
+
 func TestGetRespondentInfos(t *testing.T) {
 	t.Parallel()
 	assertion := assert.New(t)
@@ -953,87 +1033,6 @@ func TestTestCheckRespondent(t *testing.T) {
 
 	for _, testCase := range testCases {
 		isRespondent, err := respondentImpl.CheckRespondent(testCase.args.userID, testCase.args.questionnaireID)
-		if !testCase.expect.isErr {
-			assertion.NoError(err, testCase.description, "no error")
-		} else if testCase.expect.err != nil {
-			assertion.Equal(true, errors.Is(err, testCase.expect.err), testCase.description, "errorIs")
-		} else if testCase.expect.isErr {
-			assertion.Error(err, testCase.description, "any error")
-		}
-		if err != nil {
-			continue
-		}
-
-		assertion.Equal(testCase.expect.isRespondent, isRespondent, testCase.description, "isRespondent")
-	}
-}
-
-func TestCheckRespondentByResponseID(t *testing.T) {
-	t.Parallel()
-
-	assertion := assert.New(t)
-	ctx := context.Background()
-
-	questionnaireID, err := questionnaireImpl.InsertQuestionnaire(ctx, "第1回集会らん☆ぷろ募集アンケート", "第1回メンバー集会でのらん☆ぷろで発表したい人を募集します らん☆ぷろで発表したい人あつまれー！", null.NewTime(time.Now(), false), "private")
-	require.NoError(t, err)
-
-	err = administratorImpl.InsertAdministrators(questionnaireID, []string{userOne})
-	require.NoError(t, err)
-
-	responseID, err := respondentImpl.InsertRespondent(userTwo, questionnaireID, null.NewTime(time.Now(), true))
-	require.NoError(t, err)
-
-	type args struct {
-		userID     string
-		responseID int
-	}
-	type expect struct {
-		isErr        bool
-		err          error
-		isRespondent bool
-	}
-
-	type test struct {
-		description string
-		args
-		expect
-	}
-
-	testCases := []test{
-		{
-			description: "valid",
-			args: args{
-				userID:     userTwo,
-				responseID: responseID,
-			},
-			expect: expect{
-				isRespondent: true,
-			},
-		},
-		{
-			description: "not respondents",
-			args: args{
-				userID:     userThree,
-				responseID: responseID,
-			},
-			expect: expect{
-				isRespondent: false,
-			},
-		},
-		{
-			description: "questionnaireID does not exist",
-			args: args{
-				userID:     userTwo,
-				responseID: -1,
-			},
-			expect: expect{
-				isRespondent: false,
-			},
-		},
-	}
-
-	for _, testCase := range testCases {
-		isRespondent, err := respondentImpl.CheckRespondentByResponseID(testCase.args.userID, testCase.args.responseID)
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
 		} else if testCase.expect.err != nil {

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -173,7 +173,13 @@ func (m *Middleware) ResponseReadAuthenticate(next echo.HandlerFunc) echo.Handle
 			return next(c)
 		}
 
-		// TODO: 回答者以外は一時保存の回答は閲覧できない
+		// 回答者以外は一時保存の回答は閲覧できない
+		if !respondent.SubmittedAt.Valid {
+			c.Logger().Info("not submitted")
+
+			// Note: 一時保存の回答の存在もわかってはいけないので、Respondentが見つからない時と全く同じエラーを返す
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Errorf("response not found:%d", responseID))
+		}
 
 		// アンケートごとの回答閲覧権限チェック
 		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByResponseID(c.Request().Context(), userID, responseID)

--- a/router/middleware.go
+++ b/router/middleware.go
@@ -155,6 +155,7 @@ func (m *Middleware) ResponseReadAuthenticate(next echo.HandlerFunc) echo.Handle
 			return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("invalid responseID:%s(error: %w)", strResponseID, err))
 		}
 
+		// 回答者ならOK
 		isRespondent, err := m.CheckRespondentByResponseID(userID, responseID)
 		if err != nil {
 			c.Logger().Error(err)
@@ -164,6 +165,9 @@ func (m *Middleware) ResponseReadAuthenticate(next echo.HandlerFunc) echo.Handle
 			return next(c)
 		}
 
+		// TODO: 回答者以外は一時保存の回答は閲覧できない
+
+		// アンケートごとの回答閲覧権限チェック
 		responseReadPrivilegeInfo, err := m.GetResponseReadPrivilegeInfoByResponseID(c.Request().Context(), userID, responseID)
 		if errors.Is(err, model.ErrRecordNotFound) {
 			c.Logger().Info(err)

--- a/router/middleware_test.go
+++ b/router/middleware_test.go
@@ -7,12 +7,14 @@ import (
 	"net/http/httptest"
 	"strconv"
 	"testing"
+	"time"
 
 	"github.com/golang/mock/gomock"
 	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/traPtitech/anke-to/model"
 	"github.com/traPtitech/anke-to/model/mock_model"
+	"gopkg.in/guregu/null.v3"
 )
 
 type CallChecker struct {
@@ -248,11 +250,26 @@ func TestResponseReadAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			description: "この回答の回答者でなくてもhaveReadPrivilegeがtrueの場合通す",
+			description: "responseがsubmitされていない場合404",
 			args: args{
 				userID: "user1",
 				respondent: &model.Respondents{
 					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Time{}, false),
+				},
+			},
+			expect: expect{
+				statusCode: http.StatusNotFound,
+				isCalled:   false,
+			},
+		},
+		{
+			description: "この回答の回答者でなくてもsubmitされていてhaveReadPrivilegeがtrueの場合通す",
+			args: args{
+				userID: "user1",
+				respondent: &model.Respondents{
+					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Now(), true),
 				},
 				ExecutesResponseReadPrivilegeCheck: true,
 				haveReadPrivilege: true,
@@ -263,11 +280,12 @@ func TestResponseReadAuthenticate(t *testing.T) {
 			},
 		},
 		{
-			description: "この回答の回答者でなく、haveReadPrivilegeがfalseの場合403",
+			description: "この回答の回答者でなく、submitされていてhaveReadPrivilegeがfalseの場合403",
 			args: args{
 				userID: "user1",
 				respondent: &model.Respondents{
 					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Now(), true),
 				},
 				ExecutesResponseReadPrivilegeCheck: true,
 				haveReadPrivilege: false,
@@ -283,6 +301,7 @@ func TestResponseReadAuthenticate(t *testing.T) {
 				userID: "user1",
 				respondent: &model.Respondents{
 					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Now(), true),
 				},
 				ExecutesResponseReadPrivilegeCheck: true,
 				haveReadPrivilege: false,
@@ -299,6 +318,7 @@ func TestResponseReadAuthenticate(t *testing.T) {
 				userID: "user1",
 				respondent: &model.Respondents{
 					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Now(), true),
 				},
 				ExecutesResponseReadPrivilegeCheck: true,
 				haveReadPrivilege: false,
@@ -315,6 +335,7 @@ func TestResponseReadAuthenticate(t *testing.T) {
 				userID: "user1",
 				respondent: &model.Respondents{
 					UserTraqid: "user2",
+					SubmittedAt: null.NewTime(time.Now(), true),
 				},
 				ExecutesResponseReadPrivilegeCheck: true,
 				haveReadPrivilege:               false,


### PR DESCRIPTION
GET /responses/:responseIDで本人以外も一時保存の回答を見れるようになっていた。
一時保存の回答は本人以外は見えないようにしたいので、一時保存の回答では本人以外middlewareで弾くようにした。
クライアントでは本人以外の回答取得で叩かないので影響が出ないことは確認済み。