### PR TITLE
model/validationsのcontext対応

### DIFF
--- a/model/validations.go
+++ b/model/validations.go
@@ -2,12 +2,14 @@
 
 package model
 
+import "context"
+
 // IValidation ValidationのRepository
 type IValidation interface {
-	InsertValidation(lastID int, validation Validations) error
-	UpdateValidation(questionID int, validation Validations) error
-	DeleteValidation(questionID int) error
-	GetValidations(qustionIDs []int) ([]Validations, error)
+	InsertValidation(ctx context.Context, lastID int, validation Validations) error
+	UpdateValidation(ctx context.Context, questionID int, validation Validations) error
+	DeleteValidation(ctx context.Context, questionID int) error
+	GetValidations(ctx context.Context, qustionIDs []int) ([]Validations, error)
 	CheckNumberValidation(validation Validations, Body string) error
 	CheckTextValidation(validation Validations, Response string) error
 	CheckNumberValid(MinBound, MaxBound string) error

--- a/model/validations_test.go
+++ b/model/validations_test.go
@@ -180,7 +180,7 @@ func TestInsertValidation(t *testing.T) {
 			MaxBound:     testCase.args.MaxBound,
 		}
 
-		err = validationImpl.InsertValidation(questionID, validation)
+		err = validationImpl.InsertValidation(ctx, questionID, validation)
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
 		} else if testCase.expect.err != nil {
@@ -313,7 +313,7 @@ func TestUpdateValidation(t *testing.T) {
 			}
 		}
 
-		err = validationImpl.InsertValidation(questionID, validation)
+		err = validationImpl.InsertValidation(ctx, questionID, validation)
 		require.NoError(t, err)
 
 		if !testCase.args.validID {
@@ -327,7 +327,7 @@ func TestUpdateValidation(t *testing.T) {
 			MaxBound:     testCase.args.MaxBound,
 		}
 
-		err = validationImpl.UpdateValidation(questionID, validation)
+		err = validationImpl.UpdateValidation(ctx, questionID, validation)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -430,14 +430,14 @@ func TestDeleteValidation(t *testing.T) {
 			MaxBound:     testCase.args.MaxBound,
 		}
 
-		err = validationImpl.InsertValidation(questionID, validation)
+		err = validationImpl.InsertValidation(ctx, questionID, validation)
 		require.NoError(t, err)
 
 		if !testCase.args.validID {
 			questionID = -1
 		}
 
-		err = validationImpl.DeleteValidation(questionID)
+		err = validationImpl.DeleteValidation(ctx, questionID)
 
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -501,7 +501,7 @@ func TestGetValidations(t *testing.T) {
 	for _, validation := range validations {
 		questionID, err := questionImpl.InsertQuestion(ctx, questionnaireID, 1, 1, "Text", "Text", true)
 		require.NoError(t, err)
-		err = validationImpl.InsertValidation(questionID, validation)
+		err = validationImpl.InsertValidation(ctx, questionID, validation)
 		require.NoError(t, err)
 		validation.QuestionID = questionID
 		questionIDs = append(questionIDs, questionID)
@@ -540,7 +540,7 @@ func TestGetValidations(t *testing.T) {
 
 	for _, testCase := range testCases {
 
-		validations, err := validationImpl.GetValidations(testCase.args.questionIDs)
+		validations, err := validationImpl.GetValidations(ctx, testCase.args.questionIDs)
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
 		} else if testCase.expect.err != nil {

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -345,7 +345,7 @@ func (q *Questionnaire) GetQuestions(c echo.Context) error {
 		scaleLabelMap[label.QuestionID] = label
 	}
 
-	validations, err := q.GetValidations(validationIDs)
+	validations, err := q.GetValidations(c.Request().Context(), validationIDs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}

--- a/router/questions.go
+++ b/router/questions.go
@@ -104,7 +104,7 @@ func (q *Question) PostQuestion(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 	case "Text", "Number":
-		if err := q.InsertValidation(lastID,
+		if err := q.InsertValidation(c.Request().Context(), lastID,
 			model.Validations{
 				RegexPattern: req.RegexPattern,
 				MinBound:     req.MinBound,
@@ -197,7 +197,7 @@ func (q *Question) EditQuestion(c echo.Context) error {
 			return echo.NewHTTPError(http.StatusInternalServerError, err)
 		}
 	case "Text", "Number":
-		if err := q.UpdateValidation(questionID,
+		if err := q.UpdateValidation(c.Request().Context(), questionID,
 			model.Validations{
 				RegexPattern: req.RegexPattern,
 				MinBound:     req.MinBound,
@@ -229,7 +229,7 @@ func (q *Question) DeleteQuestion(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 
-	if err := q.DeleteValidation(questionID); err != nil {
+	if err := q.DeleteValidation(c.Request().Context(), questionID); err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
 

--- a/router/responses.go
+++ b/router/responses.go
@@ -88,7 +88,7 @@ func (r *Response) PostResponse(c echo.Context) error {
 		QuestionTypes[body.QuestionID] = body
 	}
 
-	validations, err := r.GetValidations(questionIDs)
+	validations, err := r.GetValidations(c.Request().Context(), questionIDs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}
@@ -242,7 +242,7 @@ func (r *Response) EditResponse(c echo.Context) error {
 		QuestionTypes[body.QuestionID] = body
 	}
 
-	validations, err := r.GetValidations(questionIDs)
+	validations, err := r.GetValidations(c.Request().Context(), questionIDs)
 	if err != nil {
 		return echo.NewHTTPError(http.StatusInternalServerError, err)
 	}

--- a/router/responses_test.go
+++ b/router/responses_test.go
@@ -524,15 +524,15 @@ func TestPostResponse(t *testing.T) {
 	// GetValidations
 	// success
 	mockValidation.EXPECT().
-		GetValidations([]int{questionIDSuccess}).
+		GetValidations(gomock.Any(), []int{questionIDSuccess}).
 		Return([]model.Validations{validation}, nil).AnyTimes()
 	// failure
 	mockValidation.EXPECT().
-		GetValidations([]int{questionIDFailure}).
+		GetValidations(gomock.Any(), []int{questionIDFailure}).
 		Return([]model.Validations{}, nil).AnyTimes()
 	// nothing
 	mockValidation.EXPECT().
-		GetValidations([]int{}).
+		GetValidations(gomock.Any(), []int{}).
 		Return([]model.Validations{}, nil).AnyTimes()
 	// CheckNumberValidation
 	// success
@@ -1188,15 +1188,15 @@ func TestEditResponse(t *testing.T) {
 	// GetValidations
 	// success
 	mockValidation.EXPECT().
-		GetValidations([]int{questionIDSuccess}).
+		GetValidations(gomock.Any(), []int{questionIDSuccess}).
 		Return([]model.Validations{validation}, nil).AnyTimes()
 	// failure
 	mockValidation.EXPECT().
-		GetValidations([]int{questionIDFailure}).
+		GetValidations(gomock.Any(), []int{questionIDFailure}).
 		Return([]model.Validations{}, nil).AnyTimes()
 	// nothing
 	mockValidation.EXPECT().
-		GetValidations([]int{}).
+		GetValidations(gomock.Any(), []int{}).
 		Return([]model.Validations{}, nil).AnyTimes()
 	// CheckNumberValidation
 	// success


### PR DESCRIPTION
modelのvalidate周りをcontextに対応させた。
これでmodel全体のcontext対応が完了する:tada:
ref #461 #632