### PR TITLE
トランザクションの基盤修正

### DIFF
--- a/model/transaction_impl.go
+++ b/model/transaction_impl.go
@@ -44,7 +44,6 @@ func getTx(ctx context.Context) (*gorm.DB, error) {
 	iDB := ctx.Value(txKey)
 	if iDB == nil {
 		return db.Session(&gorm.Session{
-			NewDB:   true,
 			Context: ctx,
 		}), nil
 	}
@@ -55,7 +54,6 @@ func getTx(ctx context.Context) (*gorm.DB, error) {
 	}
 
 	return db.Session(&gorm.Session{
-		NewDB:   true,
 		Context: ctx,
 	}), nil
 }

--- a/model/transaction_mock.go
+++ b/model/transaction_mock.go
@@ -1,0 +1,18 @@
+package model
+
+import (
+	"context"
+	"database/sql"
+	"fmt"
+)
+
+type MockTransaction struct{}
+
+func (m *MockTransaction) Do(ctx context.Context, txOption *sql.TxOptions, f func(ctx context.Context) error) error {
+	err := f(ctx)
+	if err != nil {
+		return fmt.Errorf("failed in transaction: %w", err)
+	}
+
+	return nil
+}


### PR DESCRIPTION
トランザクションを本格的に入れる前に気になっていた点をいくつか修正。
- 無駄なNewDB削除
    - ほぼ影響ないだろうけど、必要ないので消した
- txOptionがnilの場合に備える
    - nilでも動きそうな気配はあるけど怖いので
- mock作成
    - gomockでのmockだとTransaction基盤の場合テストの意味がないので