### PR TITLE
questionnaires周りのトランザクション対応

### DIFF
--- a/model/transaction_impl.go
+++ b/model/transaction_impl.go
@@ -3,7 +3,6 @@ package model
 import (
 	"context"
 	"database/sql"
-	"fmt"
 
 	"gorm.io/gorm"
 )
@@ -37,12 +36,14 @@ func (*Transaction) Do(ctx context.Context, txOption *sql.TxOptions, f func(ctx 
 	if txOption == nil {
 		err := db.Transaction(fc)
 		if err != nil {
-			return fmt.Errorf("failed in transaction: %w", err)
+			// fmt.Errorfで包むとecho.HTTPError型周りが面倒なので、そのまま返す
+			return err
 		}
 	} else {
 		err := db.Transaction(fc, txOption)
 		if err != nil {
-			return fmt.Errorf("failed in transaction: %w", err)
+			// fmt.Errorfで包むとecho.HTTPError型周りが面倒なので、そのまま返す
+			return err
 		}
 	}
 

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -334,20 +334,27 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context) error {
 func (q *Questionnaire) DeleteQuestionnaire(c echo.Context) error {
 	questionnaireID, err := getQuestionnaireID(c)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaireID: %w", err))
+		c.Logger().Errorf("failed to get questionnaireID: %w", err)
+		return echo.NewHTTPError(http.StatusInternalServerError)
 	}
 
 	err = q.ITransaction.Do(c.Request().Context(), nil, func(ctx context.Context) error {
-		if err := q.IQuestionnaire.DeleteQuestionnaire(c.Request().Context(), questionnaireID); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		err = q.IQuestionnaire.DeleteQuestionnaire(c.Request().Context(), questionnaireID)
+		if err != nil {
+			c.Logger().Errorf("failed to delete questionnaire: %w", err)
+			return err
 		}
 
-		if err := q.DeleteTargets(c.Request().Context(), questionnaireID); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		err = q.DeleteTargets(c.Request().Context(), questionnaireID)
+		if err != nil {
+			c.Logger().Errorf("failed to delete targets: %w", err)
+			return err
 		}
 
-		if err := q.DeleteAdministrators(c.Request().Context(), questionnaireID); err != nil {
-			return echo.NewHTTPError(http.StatusInternalServerError, err)
+		err = q.DeleteAdministrators(c.Request().Context(), questionnaireID)
+		if err != nil {
+			c.Logger().Errorf("failed to delete administrators: %w", err)
+			return err
 		}
 
 		return nil

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -330,7 +330,7 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context) error {
 	return c.NoContent(http.StatusOK)
 }
 
-// DeleteQuestionnaire DELETE /questonnaires/:questionnaireID
+// DeleteQuestionnaire DELETE /questionnaires/:questionnaireID
 func (q *Questionnaire) DeleteQuestionnaire(c echo.Context) error {
 	questionnaireID, err := getQuestionnaireID(c)
 	if err != nil {

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -441,3 +441,40 @@ func (q *Questionnaire) GetQuestions(c echo.Context) error {
 
 	return c.JSON(http.StatusOK, ret)
 }
+
+func createQuestionnaireMessage(questionnaireID int, title string, description string, administrators []string, resTimeLimit null.Time, targets []string) string {
+	var resTimeLimitText string
+	if resTimeLimit.Valid {
+		resTimeLimitText = resTimeLimit.Time.Local().Format("2006/01/02 15:04")
+	} else {
+		resTimeLimitText = "なし"
+	}
+
+	var targetsMentionText string
+	if len(targets) == 0 {
+		targetsMentionText = "なし"
+	} else {
+		targetsMentionText = "@" + strings.Join(targets, " @")
+	}
+
+	return fmt.Sprintf(
+		`### アンケート『[%s](https://anke-to.trap.jp/questionnaires/%d)』が作成されました
+#### 管理者
+%s
+#### 説明
+%s
+#### 回答期限
+%s
+#### 対象者
+%s
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/%d`,
+		title,
+		questionnaireID,
+		strings.Join(administrators, ","),
+		description,
+		resTimeLimitText,
+		targetsMentionText,
+		questionnaireID,
+	)
+}

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -24,13 +24,24 @@ type Questionnaire struct {
 	model.IOption
 	model.IScaleLabel
 	model.IValidation
+	model.ITransaction
 	traq.IWebhook
 }
 
 const MaxTitleLength = 50
 
 // NewQuestionnaire Questionnaireのコンストラクタ
-func NewQuestionnaire(questionnaire model.IQuestionnaire, target model.ITarget, administrator model.IAdministrator, question model.IQuestion, option model.IOption, scaleLabel model.IScaleLabel, validation model.IValidation, webhook traq.IWebhook) *Questionnaire {
+func NewQuestionnaire(
+	questionnaire model.IQuestionnaire,
+	target model.ITarget,
+	administrator model.IAdministrator,
+	question model.IQuestion,
+	option model.IOption,
+	scaleLabel model.IScaleLabel,
+	validation model.IValidation,
+	transaction model.ITransaction,
+	webhook traq.IWebhook,
+) *Questionnaire {
 	return &Questionnaire{
 		IQuestionnaire: questionnaire,
 		ITarget:        target,
@@ -39,6 +50,7 @@ func NewQuestionnaire(questionnaire model.IQuestionnaire, target model.ITarget, 
 		IOption:        option,
 		IScaleLabel:    scaleLabel,
 		IValidation:    validation,
+		ITransaction:   transaction,
 		IWebhook:       webhook,
 	}
 }

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -212,14 +212,15 @@ func (q *Questionnaire) PostQuestionnaire(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to create a questionnaire")
 	}
 
+	now := time.Now()
 	return c.JSON(http.StatusCreated, map[string]interface{}{
 		"questionnaireID": questionnaireID,
 		"title":           req.Title,
 		"description":     req.Description,
 		"res_time_limit":  req.ResTimeLimit,
 		"deleted_at":      "NULL",
-		"created_at":      time.Now().Format(time.RFC3339),
-		"modified_at":     time.Now().Format(time.RFC3339),
+		"created_at":      now.Format(time.RFC3339),
+		"modified_at":     now.Format(time.RFC3339),
 		"res_shared_to":   req.ResSharedTo,
 		"targets":         req.Targets,
 		"administrators":  req.Administrators,

--- a/router/questionnaires.go
+++ b/router/questionnaires.go
@@ -245,7 +245,7 @@ func (q *Questionnaire) GetQuestionnaire(c echo.Context) error {
 	})
 }
 
-// EditQuestionnaire PATCH /questonnaires/:questionnaireID
+// EditQuestionnaire PATCH /questionnaires/:questionnaireID
 func (q *Questionnaire) EditQuestionnaire(c echo.Context) error {
 	questionnaireID, err := getQuestionnaireID(c)
 	if err != nil {

--- a/router/questionnaires_test.go
+++ b/router/questionnaires_test.go
@@ -1,11 +1,23 @@
 package router
 
 import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/go-playground/validator/v10"
+	"github.com/golang/mock/gomock"
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
+	"github.com/traPtitech/anke-to/model"
+	"github.com/traPtitech/anke-to/model/mock_model"
+	"github.com/traPtitech/anke-to/traq/mock_traq"
 	"gopkg.in/guregu/null.v3"
 )
 
@@ -352,6 +364,315 @@ func TestGetQuestionnaireValidate(t *testing.T) {
 				assert.Error(t, err)
 			} else {
 				assert.NoError(t, err)
+			}
+		})
+	}
+}
+
+func TestPostQuestionnaire(t *testing.T) {
+	t.Parallel()
+
+	ctrl := gomock.NewController(t)
+	defer ctrl.Finish()
+
+	mockQuestionnaire := mock_model.NewMockIQuestionnaire(ctrl)
+	mockTarget := mock_model.NewMockITarget(ctrl)
+	mockAdministrator := mock_model.NewMockIAdministrator(ctrl)
+	mockQuestion := mock_model.NewMockIQuestion(ctrl)
+	mockOption := mock_model.NewMockIOption(ctrl)
+	mockScaleLabel := mock_model.NewMockIScaleLabel(ctrl)
+	mockValidation := mock_model.NewMockIValidation(ctrl)
+	mockTransaction := &model.MockTransaction{}
+	mockWebhook := mock_traq.NewMockIWebhook(ctrl)
+
+	questionnaire := NewQuestionnaire(
+		mockQuestionnaire,
+		mockTarget,
+		mockAdministrator,
+		mockQuestion,
+		mockOption,
+		mockScaleLabel,
+		mockValidation,
+		mockTransaction,
+		mockWebhook,
+	)
+
+	type expect struct {
+		statusCode int
+	}
+	type test struct {
+		description               string
+		invalidRequest            bool
+		request                   PostAndEditQuestionnaireRequest
+		ExecutesCreation          bool
+		questionnaireID           int
+		InsertQuestionnaireError  error
+		InsertTargetsError        error
+		InsertAdministratorsError error
+		PostMessageError          error
+		expect
+	}
+
+	testCases := []test{
+		{
+			description:    "リクエストの形式が誤っているので400",
+			invalidRequest: true,
+			expect: expect{
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
+			description: "validationで落ちるので400",
+			request:     PostAndEditQuestionnaireRequest{},
+			expect: expect{
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
+			description: "resTimeLimitが誤っているので400",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Now().Add(-24*time.Hour), true),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			expect: expect{
+				statusCode: http.StatusBadRequest,
+			},
+		},
+		{
+			description: "InsertQuestionnaireがエラーなので500",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation:         true,
+			InsertQuestionnaireError: errors.New("InsertQuestionnaireError"),
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			description: "InsertTargetsがエラーなので500",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation:   true,
+			questionnaireID:    1,
+			InsertTargetsError: errors.New("InsertTargetsError"),
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			description: "InsertAdministratorsがエラーなので500",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation:          true,
+			questionnaireID:           1,
+			InsertAdministratorsError: errors.New("InsertAdministratorsError"),
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			description: "PostMessageがエラーなので500",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation: true,
+			questionnaireID:  1,
+			PostMessageError: errors.New("PostMessageError"),
+			expect: expect{
+				statusCode: http.StatusInternalServerError,
+			},
+		},
+		{
+			description: "一般的なリクエストなので201",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation: true,
+			questionnaireID:  1,
+			expect: expect{
+				statusCode: http.StatusCreated,
+			},
+		},
+		{
+			description: "questionnaireIDが0でも201",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Time{}, false),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation: true,
+			questionnaireID:  0,
+			expect: expect{
+				statusCode: http.StatusCreated,
+			},
+		},
+		{
+			description: "回答期限が設定されていてもでも201",
+			request: PostAndEditQuestionnaireRequest{
+				Title:          "第1回集会らん☆ぷろ募集アンケート",
+				Description:    "第1回集会らん☆ぷろ参加者募集",
+				ResTimeLimit:   null.NewTime(time.Now().Add(24*time.Hour), true),
+				ResSharedTo:    "public",
+				Targets:        []string{},
+				Administrators: []string{"mazrean"},
+			},
+			ExecutesCreation: true,
+			questionnaireID:  1,
+			expect: expect{
+				statusCode: http.StatusCreated,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			var request io.Reader
+			if testCase.invalidRequest {
+				request = strings.NewReader("test")
+			} else {
+				buf := bytes.NewBuffer(nil)
+				err := json.NewEncoder(buf).Encode(testCase.request)
+				if err != nil {
+					t.Errorf("failed to encode request: %v", err)
+				}
+
+				request = buf
+			}
+
+			e := echo.New()
+			req := httptest.NewRequest(http.MethodPost, "/questionnaires", request)
+			rec := httptest.NewRecorder()
+			req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+			c := e.NewContext(req, rec)
+
+			c.Set(validatorKay, validator.New())
+
+			if testCase.ExecutesCreation {
+				// 時刻は完全一致しないためその対応
+				var mockTimeLimit interface{}
+				if testCase.request.ResTimeLimit.Valid {
+					mockTimeLimit = gomock.Any()
+				} else {
+					mockTimeLimit = testCase.request.ResTimeLimit
+				}
+
+				mockQuestionnaire.
+					EXPECT().
+					InsertQuestionnaire(
+						c.Request().Context(),
+						testCase.request.Title,
+						testCase.request.Description,
+						mockTimeLimit,
+						testCase.request.ResSharedTo,
+					).
+					Return(testCase.questionnaireID, testCase.InsertQuestionnaireError)
+
+				if testCase.InsertQuestionnaireError == nil {
+					mockTarget.
+						EXPECT().
+						InsertTargets(
+							c.Request().Context(),
+							testCase.questionnaireID,
+							testCase.request.Targets,
+						).
+						Return(testCase.InsertTargetsError)
+
+					if testCase.InsertTargetsError == nil {
+						mockAdministrator.
+							EXPECT().
+							InsertAdministrators(
+								c.Request().Context(),
+								testCase.questionnaireID,
+								testCase.request.Administrators,
+							).
+							Return(testCase.InsertAdministratorsError)
+
+						if testCase.InsertAdministratorsError == nil {
+							mockWebhook.
+								EXPECT().
+								PostMessage(gomock.Any()).
+								Return(testCase.PostMessageError)
+						}
+					}
+				}
+			}
+
+			e.HTTPErrorHandler(questionnaire.PostQuestionnaire(c), c)
+
+			t.Log(rec.Body.String())
+			assert.Equal(t, testCase.expect.statusCode, rec.Code, "status code")
+
+			if testCase.expect.statusCode == http.StatusCreated {
+				var questionnaire map[string]interface{}
+				err := json.NewDecoder(rec.Body).Decode(&questionnaire)
+				if err != nil {
+					t.Errorf("failed to decode response body: %v", err)
+				}
+
+				assert.Equal(t, float64(testCase.questionnaireID), questionnaire["questionnaireID"], "questionnaireID")
+				assert.Equal(t, testCase.request.Title, questionnaire["title"], "title")
+				assert.Equal(t, testCase.request.Description, questionnaire["description"], "description")
+				if testCase.request.ResTimeLimit.Valid {
+					strResTimeLimit, ok := questionnaire["res_time_limit"].(string)
+					assert.True(t, ok, "res_time_limit convert")
+					resTimeLimit, err := time.Parse(time.RFC3339, strResTimeLimit)
+					assert.NoError(t, err, "res_time_limit parse")
+
+					assert.WithinDuration(t, testCase.request.ResTimeLimit.Time, resTimeLimit, 2*time.Second, "resTimeLimit")
+				} else {
+					assert.Nil(t, questionnaire["res_time_limit"], "resTimeLimit nil")
+				}
+				assert.Equal(t, testCase.request.ResSharedTo, questionnaire["res_shared_to"], "resSharedTo")
+
+				strCreatedAt, ok := questionnaire["created_at"].(string)
+				assert.True(t, ok, "created_at convert")
+				createdAt, err := time.Parse(time.RFC3339, strCreatedAt)
+				assert.NoError(t, err, "created_at parse")
+				assert.WithinDuration(t, time.Now(), createdAt, time.Second, "created_at")
+
+				strModifiedAt, ok := questionnaire["modified_at"].(string)
+				assert.True(t, ok, "modified_at convert")
+				modifiedAt, err := time.Parse(time.RFC3339, strModifiedAt)
+				assert.NoError(t, err, "modified_at parse")
+				assert.WithinDuration(t, time.Now(), modifiedAt, time.Second, "modified_at")
+
+				assert.ElementsMatch(t, testCase.request.Targets, questionnaire["targets"], "targets")
+				assert.ElementsMatch(t, testCase.request.Administrators, questionnaire["administrators"], "administrators")
 			}
 		})
 	}

--- a/router/questionnaires_test.go
+++ b/router/questionnaires_test.go
@@ -1110,3 +1110,265 @@ func TestDeleteQuestionnaire(t *testing.T) {
 		})
 	}
 }
+
+func TestCreateQuestionnaireMessage(t *testing.T) {
+	t.Parallel()
+
+	type args struct {
+		questionnaireID int
+		title           string
+		description     string
+		administrators  []string
+		resTimeLimit    null.Time
+		targets         []string
+	}
+	type expect struct {
+		message string
+	}
+	type test struct {
+		description string
+		args
+		expect
+	}
+
+	tm, err := time.ParseInLocation("2006/01/02 15:04", "2021/10/01 09:06", time.Local)
+	if err != nil {
+		t.Errorf("failed to parse time: %v", err)
+	}
+
+	testCases := []test{
+		{
+			description: "通常の引数なので問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "questionnaireIDが0でも問題なし",
+			args: args{
+				questionnaireID: 0,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/0)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/0`,
+			},
+		},
+		{
+			// 実際には発生しないけど念の為
+			description: "titleが空文字でも問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "説明が空文字でも問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "administrator複数人でも問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1", "administrator2"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1,administrator2
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			// 実際には発生しないけど念の為
+			description: "administratorがいなくても問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "回答期限なしでも問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.NewTime(time.Time{}, false),
+				targets:         []string{"target1"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+なし
+#### 対象者
+@target1
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "対象者が複数人でも問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{"target1", "target2"},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+@target1 @target2
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+		{
+			description: "対象者がいなくても問題なし",
+			args: args{
+				questionnaireID: 1,
+				title:           "title",
+				description:     "description",
+				administrators:  []string{"administrator1"},
+				resTimeLimit:    null.TimeFrom(tm),
+				targets:         []string{},
+			},
+			expect: expect{
+				message: `### アンケート『[title](https://anke-to.trap.jp/questionnaires/1)』が作成されました
+#### 管理者
+administrator1
+#### 説明
+description
+#### 回答期限
+2021/10/01 09:06
+#### 対象者
+なし
+#### 回答リンク
+https://anke-to.trap.jp/responses/new/1`,
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.description, func(t *testing.T) {
+			message := createQuestionnaireMessage(
+				testCase.args.questionnaireID,
+				testCase.args.title,
+				testCase.args.description,
+				testCase.args.administrators,
+				testCase.args.resTimeLimit,
+				testCase.args.targets,
+			)
+
+			assert.Equal(t, testCase.expect.message, message)
+		})
+	}
+}

--- a/wire.go
+++ b/wire.go
@@ -20,6 +20,7 @@ var (
 	scaleLabelBind    = wire.Bind(new(model.IScaleLabel), new(*model.ScaleLabel))
 	targetBind        = wire.Bind(new(model.ITarget), new(*model.Target))
 	validationBind    = wire.Bind(new(model.IValidation), new(*model.Validation))
+	transactionBind   = wire.Bind(new(model.ITransaction), new(*model.Transaction))
 
 	webhookBind = wire.Bind(new(traq.IWebhook), new(*traq.Webhook))
 )
@@ -42,6 +43,7 @@ func InjectAPIServer() *router.API {
 		model.NewScaleLabel,
 		model.NewTarget,
 		model.NewValidation,
+		model.NewTransaction,
 		traq.NewWebhook,
 		administratorBind,
 		optionBind,
@@ -52,6 +54,7 @@ func InjectAPIServer() *router.API {
 		scaleLabelBind,
 		targetBind,
 		validationBind,
+		transactionBind,
 		webhookBind,
 	)
 

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -29,8 +29,9 @@ func InjectAPIServer() *router.API {
 	option := model.NewOption()
 	scaleLabel := model.NewScaleLabel()
 	validation := model.NewValidation()
+	transaction := model.NewTransaction()
 	webhook := traq.NewWebhook()
-	routerQuestionnaire := router.NewQuestionnaire(questionnaire, target, administrator, question, option, scaleLabel, validation, webhook)
+	routerQuestionnaire := router.NewQuestionnaire(questionnaire, target, administrator, question, option, scaleLabel, validation, transaction, webhook)
 	routerQuestion := router.NewQuestion(validation, question, option, scaleLabel)
 	response := model.NewResponse()
 	routerResponse := router.NewResponse(questionnaire, validation, scaleLabel, respondent, response)
@@ -52,6 +53,7 @@ var (
 	scaleLabelBind    = wire.Bind(new(model.IScaleLabel), new(*model.ScaleLabel))
 	targetBind        = wire.Bind(new(model.ITarget), new(*model.Target))
 	validationBind    = wire.Bind(new(model.IValidation), new(*model.Validation))
+	transactionBind   = wire.Bind(new(model.ITransaction), new(*model.Transaction))
 
 	webhookBind = wire.Bind(new(traq.IWebhook), new(*traq.Webhook))
 )


### PR DESCRIPTION
トランザクションに対応して途中で失敗したときにDBへの変更が消えるようにした。
テストなしの状態でこの変更を入れるのは怖かったのでテストの追加もしている。
ref #461 