### PR TITLE
releaseのjob修正

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,6 +11,9 @@ env:
 jobs:
   image:
     name: Build Docker Image
+    strategy:
+      matrix:
+        platform: [linux/amd64, linux/arm64]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
@@ -29,7 +32,7 @@ jobs:
         with:
           context: .
           push: true
-          platforms: linux/amd64,linux/arm64
+          platforms: ${{ matrix.platform }}
           tags: ghcr.io/traptitech/${{ env.IMAGE_NAME }}:latest
           cache-from: type=gha
           cache-to: type=gha,mode=max


### PR DESCRIPTION
CPUのアーキテクチャごとに走らせることで、先にamd64のimageをpushしてリリースを打てるようにした。
これとほぼ同じことをすればおそらくmasterのimageもarm版を作れると思うけど、今手が回らないので後回し。