### PR TITLE
全テーブルの32文字id対応

### DIFF
--- a/model/administrators_impl.go
+++ b/model/administrators_impl.go
@@ -19,7 +19,7 @@ func NewAdministrator() *Administrator {
 // Administrators administratorsテーブルの構造体
 type Administrators struct {
 	QuestionnaireID int    `gorm:"type:int(11);not null;primaryKey"`
-	UserTraqid      string `gorm:"type:char(30);size:30;not null;primaryKey"`
+	UserTraqid      string `gorm:"type:varchar(32);size:32;not null;primaryKey"`
 }
 
 // InsertAdministrators アンケートの管理者を追加

--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -25,7 +25,7 @@ func NewRespondent() *Respondent {
 type Respondents struct {
 	ResponseID      int            `json:"responseID" gorm:"column:response_id;type:int(11) AUTO_INCREMENT;not null;primaryKey"`
 	QuestionnaireID int            `json:"questionnaireID" gorm:"type:int(11);not null"`
-	UserTraqid      string         `json:"user_traq_id,omitempty" gorm:"type:char(30);size:30;default:NULL"`
+	UserTraqid      string         `json:"user_traq_id,omitempty" gorm:"type:varchar(32);size:32;default:NULL"`
 	ModifiedAt      time.Time      `json:"modified_at,omitempty" gorm:"type:timestamp;not null;default:CURRENT_TIMESTAMP"`
 	SubmittedAt     null.Time      `json:"submitted_at,omitempty" gorm:"type:TIMESTAMP NULL;default:NULL"`
 	DeletedAt       gorm.DeletedAt `json:"deleted_at,omitempty" gorm:"type:TIMESTAMP NULL;default:NULL"`

--- a/model/targets_impl.go
+++ b/model/targets_impl.go
@@ -16,7 +16,7 @@ func NewTarget() *Target {
 //Targets targetsテーブルの構造体
 type Targets struct {
 	QuestionnaireID int    `gorm:"type:int(11) AUTO_INCREMENT;not null;primaryKey"`
-	UserTraqid      string `gorm:"type:char(30);size:30;not null;primaryKey"`
+	UserTraqid      string `gorm:"type:varchar(32);size:32;not null;primaryKey"`
 }
 
 // InsertTargets アンケートの対象を追加


### PR DESCRIPTION
緊急度が結構高いことが発覚したので全テーブルの32文字id対応をした。
手元に本番環境のデータを持ってきての動作確認で特に壊れたりはしないことは確認済み。
Close #425 