### PR TITLE
♻️ dockerizeの導入

### DIFF
--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -14,3 +14,4 @@ RUN apk add --no-cache openssl \
  && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
  && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
+ENTRYPOINT dockerize -timeout 10s -wait tcp://mysql:3306 && air -c docker/dev/.air.toml

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -8,4 +8,9 @@ RUN go install github.com/cosmtrek/air@v1.27.3
 COPY go.mod go.sum ./
 RUN go mod download
 
-CMD ["air", "-c", "docker/dev/.air.toml"]
+ENV DOCKERIZE_VERSION v0.6.1
+RUN apk add --no-cache openssl \
+ && wget https://github.com/jwilder/dockerize/releases/download/$DOCKERIZE_VERSION/dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+ && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
+ && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
+

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -14,4 +14,4 @@ RUN apk add --no-cache openssl \
  && tar -C /usr/local/bin -xzvf dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz \
  && rm dockerize-alpine-linux-amd64-$DOCKERIZE_VERSION.tar.gz
 
-ENTRYPOINT dockerize -timeout 10s -wait tcp://mysql:3306 && air -c docker/dev/.air.toml
+ENTRYPOINT dockerize -timeout 10s -wait tcp://mysql:3306  air -c docker/dev/.air.toml

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -18,16 +18,6 @@ services:
       - "1323:1323"
     volumes:
       - "../../:/go/src/github.com/traPtitech/anke-to"
-    entrypoint:
-      - dockerize
-      - -timeout
-      - 10s
-      - -wait
-      - tcp://mysql:3306
-    command:
-      - air
-      - -c
-      - docker/dev/.air.toml
     depends_on:
       - mysql
 

--- a/docker/dev/docker-compose.yaml
+++ b/docker/dev/docker-compose.yaml
@@ -18,6 +18,16 @@ services:
       - "1323:1323"
     volumes:
       - "../../:/go/src/github.com/traPtitech/anke-to"
+    entrypoint:
+      - dockerize
+      - -timeout
+      - 10s
+      - -wait
+      - tcp://mysql:3306
+    command:
+      - air
+      - -c
+      - docker/dev/.air.toml
     depends_on:
       - mysql
 


### PR DESCRIPTION
close: #612 

- docker-compose.yamlにCommandとEntrypointを用いてdockerを起動するようにしました
- DockerfileのＣＭＤをdocker-compose.yamlのコマンドに書くようにした(こうしないとanke-toが起動しなかった)