### PR TITLE
model/responsesからprimaryKey削除

### DIFF
--- a/model/responses_impl.go
+++ b/model/responses_impl.go
@@ -18,8 +18,8 @@ func NewResponse() *Response {
 
 //Responses responseテーブルの構造体
 type Responses struct {
-	ResponseID int            `json:"-" gorm:"type:int(11);not null;primaryKey"`
-	QuestionID int            `json:"-" gorm:"type:int(11);not null;primaryKey"`
+	ResponseID int            `json:"-" gorm:"type:int(11);not null"`
+	QuestionID int            `json:"-" gorm:"type:int(11);not null"`
 	Body       null.String    `json:"response" gorm:"type:text;default:NULL"`
 	ModifiedAt time.Time      `json:"-" gorm:"type:timestamp;not null;dafault:CURRENT_TIMESTAMP"`
 	DeletedAt  gorm.DeletedAt `json:"-" gorm:"type:TIMESTAMP NULL;default:NULL"`


### PR DESCRIPTION
- ローカルでチェックボックスの選択肢を複数選択した時エラーになっていた
- 本番環境ではDBにprimaryKeyがついていないのでエラーになっていなかった