### PR TITLE
MultipleChoice修正

### DIFF
--- a/client/src/pages/ResponseDetails.vue
+++ b/client/src/pages/ResponseDetails.vue
@@ -357,6 +357,13 @@ export default {
         }
         switch (question.type) {
           case 'MultipleChoice':
+            if (question.selected) {
+              body.option_response = [question.selected];
+            } else {
+              body.option_response = [];
+            }
+
+            break;
           case 'Checkbox':
             Object.keys(question.isSelected).forEach(key => {
               if (question.isSelected[key]) {


### PR DESCRIPTION
クライアントではCheckboxと形式が違かったので、 #771 で壊れたっぽい。
元に戻すのと、未選択時に`[]`にするのとで対応した。