### PR TITLE
MultipleChoiceとCheckboxの回答のソートに対応

### DIFF
--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -7,6 +7,7 @@ import (
 	"math"
 	"sort"
 	"strconv"
+	"strings"
 	"time"
 
 	"gopkg.in/guregu/null.v4"
@@ -466,8 +467,8 @@ func sortRespondentDetail(sortNum int, questionNum int, respondentDetails []Resp
 			return choiceI < choiceJ
 		}
 		if bodyI.QuestionType == "Checkbox" {
-			selectionsI := joinStringArray(bodyI.OptionResponse, ", ")
-			selectionsJ := joinStringArray(bodyJ.OptionResponse, ", ")
+			selectionsI := strings.Join(bodyI.OptionResponse, ", ")
+			selectionsJ := strings.Join(bodyJ.OptionResponse, ", ")
 			if sortNum < 0 {
 				return selectionsI > selectionsJ
 			}
@@ -480,15 +481,4 @@ func sortRespondentDetail(sortNum int, questionNum int, respondentDetails []Resp
 	})
 
 	return respondentDetails, nil
-}
-
-func joinStringArray(strArray []string, separator string) string {
-	var result string
-	for i, str := range strArray {
-		result += str
-		if i != len(strArray)-1 {
-			result += separator
-		}
-	}
-	return result
 }

--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -452,10 +452,26 @@ func sortRespondentDetail(sortNum int, questionNum int, respondentDetails []Resp
 			return numi < numj
 		}
 		if bodyI.QuestionType == "MultipleChoice" {
-			if sortNum < 0 {
-				return bodyI.OptionResponse[0] > bodyJ.OptionResponse[0]
+			choiceI := ""
+			if len(bodyI.OptionResponse) > 0 {
+				choiceI = bodyI.OptionResponse[0]
 			}
-			return bodyI.OptionResponse[0] < bodyJ.OptionResponse[0]
+			choiceJ := ""
+			if len(bodyJ.OptionResponse) > 0 {
+				choiceJ = bodyJ.OptionResponse[0]
+			}
+			if sortNum < 0 {
+				return choiceI > choiceJ
+			}
+			return choiceI < choiceJ
+		}
+		if bodyI.QuestionType == "Checkbox" {
+			selectionsI := joinStringArray(bodyI.OptionResponse, ", ")
+			selectionsJ := joinStringArray(bodyJ.OptionResponse, ", ")
+			if sortNum < 0 {
+				return selectionsI > selectionsJ
+			}
+			return selectionsI < selectionsJ
 		}
 		if sortNum < 0 {
 			return bodyI.Body.String > bodyJ.Body.String
@@ -464,4 +480,15 @@ func sortRespondentDetail(sortNum int, questionNum int, respondentDetails []Resp
 	})
 
 	return respondentDetails, nil
+}
+
+func joinStringArray(strArray []string, separator string) string {
+	var result string
+	for i, str := range strArray {
+		result += str
+		if i != len(strArray)-1 {
+			result += separator
+		}
+	}
+	return result
 }

--- a/model/respondents_impl.go
+++ b/model/respondents_impl.go
@@ -451,6 +451,12 @@ func sortRespondentDetail(sortNum int, questionNum int, respondentDetails []Resp
 			}
 			return numi < numj
 		}
+		if bodyI.QuestionType == "MultipleChoice" {
+			if sortNum < 0 {
+				return bodyI.OptionResponse[0] > bodyJ.OptionResponse[0]
+			}
+			return bodyI.OptionResponse[0] < bodyJ.OptionResponse[0]
+		}
 		if sortNum < 0 {
 			return bodyI.Body.String > bodyJ.Body.String
 		}


### PR DESCRIPTION
`GET /results/{questionnaireID}`のクエリパラメータ`sort`でMultipleChoiceとCheckboxの質問を指定してもソートされなかった