### PR TITLE
Chore/go version update

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.17
+          go-version: 1.20
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.17
+          go-version: 1.20
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2.1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -17,7 +17,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -33,7 +33,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -68,7 +68,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v2
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - uses: actions/cache@v2.1.7
         with:
@@ -99,7 +99,7 @@ jobs:
     steps:
       - uses: actions/setup-go@v1
         with:
-          go-version: 1.20
+          go-version: '1.20'
       - uses: actions/checkout@v3
       - name: golangci-lint
         uses: reviewdog/action-golangci-lint@v2.1

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.3.0
 
 # build backend
-FROM golang:1.17.6-alpine as server-build
+FROM golang:1.20.7-alpine as server-build
 RUN --mount=type=cache,target=/var/cache/apk \
   apk add --update git
 

--- a/client/package-lock.json
+++ b/client/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "client",
       "version": "0.1.0",
       "dependencies": {
         "@traptitech/traq": "^3.4.5-1",

--- a/docker/dev/Dockerfile
+++ b/docker/dev/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-alpine as build-step
+FROM golang:1.20.7-alpine as build-step
 RUN apk add --update --no-cache ca-certificates git
 
 WORKDIR /go/src/github.com/traPtitech/anke-to

--- a/docker/staging/Dockerfile
+++ b/docker/staging/Dockerfile
@@ -1,7 +1,7 @@
 # syntax = docker/dockerfile:1.3.0
 
 # build backend
-FROM golang:1.17.7-alpine as server-build
+FROM golang:1.20.7-alpine as server-build
 RUN --mount=type=cache,target=/var/cache/apk \
   apk add --update git
 

--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.17.3-alpine as builder
+FROM golang:1.20.7-alpine as builder
 RUN apk add --update --no-cache ca-certificates git \
  && apk add --no-cache gcc libc-dev \
  && apk add --no-cache openssl

--- a/docker/tuning/Dockerfile.server
+++ b/docker/tuning/Dockerfile.server
@@ -1,4 +1,4 @@
-FROM golang:1.17.7-alpine as build-step
+FROM golang:1.20.7-alpine as build-step
 RUN apk add --update --no-cache ca-certificates git
 
 WORKDIR /go/src/github.com/traPtitech/anke-to

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/traPtitech/anke-to
 
-go 1.17
+go 1.20
 
 require (
 	github.com/golang/mock v1.6.0

--- a/model/administrators_test.go
+++ b/model/administrators_test.go
@@ -57,7 +57,7 @@ func setupAdministratorTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(&administratorTestQuestionnaireDatas[i].questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", questionnaireData, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", questionnaireData, err)
 		}
 
 		for _, administrator := range questionnaireData.administrators {
@@ -68,7 +68,7 @@ func setupAdministratorTest(t *testing.T) {
 					UserTraqid:      administrator,
 				}).Error
 			if err != nil {
-				t.Errorf("failed to create administrator(%s): %w", administrator, err)
+				t.Errorf("failed to create administrator(%s): %v", administrator, err)
 			}
 		}
 	}
@@ -105,7 +105,7 @@ func insertAdministratorsTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -176,7 +176,7 @@ func insertAdministratorsTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(&testCase.args.questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", testCase.args.questionnaire, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", testCase.args.questionnaire, err)
 		}
 
 		err = administratorImpl.InsertAdministrators(ctx, testCase.args.questionnaire.ID, testCase.args.administrators)
@@ -198,7 +198,7 @@ func insertAdministratorsTest(t *testing.T) {
 				First(&actualAdministrators).Error
 
 			if errors.Is(err, gorm.ErrRecordNotFound) {
-				t.Errorf("no administrator(%s): %w", administrator, err)
+				t.Errorf("no administrator(%s): %v", administrator, err)
 			}
 		}
 	}
@@ -289,7 +289,7 @@ func deleteAdministratorsTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(&testCase.args.questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", testCase.args.questionnaire, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", testCase.args.questionnaire, err)
 		}
 
 		err = administratorImpl.DeleteAdministrators(ctx, testCase.args.questionnaire.ID)
@@ -309,7 +309,7 @@ func deleteAdministratorsTest(t *testing.T) {
 			Where("questionnaire_id = ?", testCase.args.questionnaire.ID).
 			Find(&administrators).Error
 		if err != nil {
-			t.Errorf("failed to get administrators(%s): %w", testCase.description, err)
+			t.Errorf("failed to get administrators(%s): %v", testCase.description, err)
 		}
 
 		assertion.Len(administrators, 0, testCase.description, "administrator length")
@@ -434,7 +434,7 @@ func checkQuestionnaireAdminTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 

--- a/model/questionnaires_test.go
+++ b/model/questionnaires_test.go
@@ -282,7 +282,7 @@ func setupQuestionnairesTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(data.questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", data, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", data, err)
 		}
 
 		for _, target := range data.targets {
@@ -299,7 +299,7 @@ func setupQuestionnairesTest(t *testing.T) {
 					UserTraqid:      target,
 				}).Error
 			if err != nil {
-				t.Errorf("failed to create target: %w", err)
+				t.Errorf("failed to create target: %v", err)
 			}
 		}
 
@@ -317,7 +317,7 @@ func setupQuestionnairesTest(t *testing.T) {
 					UserTraqid:      administrator,
 				}).Error
 			if err != nil {
-				t.Errorf("failed to create target: %w", err)
+				t.Errorf("failed to create target: %v", err)
 			}
 		}
 
@@ -468,7 +468,7 @@ func insertQuestionnaireTest(t *testing.T) {
 			Where("id = ?", questionnaireID).
 			First(&questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to get questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to get questionnaire(%s): %v", testCase.description, err)
 		}
 
 		assertion.Equal(testCase.args.title, questionnaire.Title, testCase.description, "title")
@@ -657,7 +657,7 @@ func updateQuestionnaireTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(&questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to create questionnaire(%s): %v", testCase.description, err)
 		}
 
 		createdAt := questionnaire.CreatedAt
@@ -680,7 +680,7 @@ func updateQuestionnaireTest(t *testing.T) {
 			Where("id = ?", questionnaireID).
 			First(&questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to get questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to get questionnaire(%s): %v", testCase.description, err)
 		}
 
 		assertion.Equal(after.title, questionnaire.Title, testCase.description, "title")
@@ -702,7 +702,7 @@ func updateQuestionnaireTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -732,7 +732,7 @@ func updateQuestionnaireTest(t *testing.T) {
 			if err == nil {
 				t.Errorf("Succeeded with invalid questionnaireID")
 			} else {
-				t.Errorf("failed to update questionnaire(invalid questionnireID): %w", err)
+				t.Errorf("failed to update questionnaire(invalid questionnireID): %v", err)
 			}
 		}
 	}
@@ -783,7 +783,7 @@ func deleteQuestionnaireTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(&questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to create questionnaire(%s): %v", testCase.description, err)
 		}
 
 		questionnaireID := questionnaire.ID
@@ -805,7 +805,7 @@ func deleteQuestionnaireTest(t *testing.T) {
 			Where("id = ?", questionnaireID).
 			Find(&questionnaire).Error
 		if err != nil {
-			t.Errorf("failed to get questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to get questionnaire(%s): %v", testCase.description, err)
 		}
 
 		assertion.True(questionnaire.DeletedAt.Valid, testCase.description, "id")
@@ -822,7 +822,7 @@ func deleteQuestionnaireTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -836,7 +836,7 @@ func deleteQuestionnaireTest(t *testing.T) {
 		if err == nil {
 			t.Errorf("Succeeded with invalid questionnaireID")
 		} else {
-			t.Errorf("failed to update questionnaire(invalid questionnireID): %w", err)
+			t.Errorf("failed to update questionnaire(invalid questionnireID): %v", err)
 		}
 	}
 }
@@ -1075,7 +1075,7 @@ func getQuestionnairesTest(t *testing.T) {
 			Where("deleted_at IS NULL").
 			Count(&questionnaireNum).Error
 		if err != nil {
-			t.Errorf("failed to count questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to count questionnaire(%s): %v", testCase.description, err)
 		}
 
 		actualQuestionnaireIDs := []int{}
@@ -1190,7 +1190,7 @@ func getAdminQuestionnairesTest(t *testing.T) {
 			Where("id IN (?)", actualQuestionnaireIDs).
 			Find(&expectQuestionnaires).Error
 		if err != nil {
-			t.Errorf("failed to get questionnaires(%s): %w", testCase.description, err)
+			t.Errorf("failed to get questionnaires(%s): %v", testCase.description, err)
 		}
 
 		for _, expectQuestionnaire := range expectQuestionnaires {
@@ -1234,7 +1234,7 @@ func getQuestionnaireInfoTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -1568,7 +1568,7 @@ func getQuestionnaireLimitTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -1655,7 +1655,7 @@ func getQuestionnaireLimitByResponseIDTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get response(make invalid responseID): %w", err)
+			t.Errorf("failed to get response(make invalid responseID): %v", err)
 			break
 		}
 
@@ -1746,7 +1746,7 @@ func getResponseReadPrivilegeInfoByResponseIDTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -1763,7 +1763,7 @@ func getResponseReadPrivilegeInfoByResponseIDTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get response(make invalid responseID): %w", err)
+			t.Errorf("failed to get response(make invalid responseID): %v", err)
 			break
 		}
 
@@ -1917,7 +1917,7 @@ func getResponseReadPrivilegeInfoByQuestionnaireIDTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 

--- a/model/questions_test.go
+++ b/model/questions_test.go
@@ -65,7 +65,7 @@ func setupQuestionsTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(questionnaireData.Questionnaires).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", questionnaireData, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", questionnaireData, err)
 		}
 
 		for _, administrator := range questionnaireData.administrators {
@@ -76,7 +76,7 @@ func setupQuestionsTest(t *testing.T) {
 					UserTraqid:      administrator,
 				}).Error
 			if err != nil {
-				t.Errorf("failed to create administrator(%s): %w", administrator, err)
+				t.Errorf("failed to create administrator(%s): %v", administrator, err)
 			}
 		}
 	}
@@ -192,7 +192,7 @@ func setupQuestionsTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(questionData.Questions).Error
 		if err != nil {
-			t.Errorf("failed to create questionnaire(%+v): %w", questionData, err)
+			t.Errorf("failed to create questionnaire(%+v): %v", questionData, err)
 		}
 
 		if !questionData.Questions.DeletedAt.Valid {
@@ -235,7 +235,7 @@ func insertQuestionTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -423,7 +423,7 @@ func insertQuestionTest(t *testing.T) {
 			Where("id = ?", questionID).
 			First(&question).Error
 		if err != nil {
-			t.Errorf("failed to get question(%s): %w", testCase.description, err)
+			t.Errorf("failed to get question(%s): %v", testCase.description, err)
 		}
 
 		assertion.Equal(testCase.args.QuestionnaireID, question.QuestionnaireID, testCase.description, "questionnaire_id")
@@ -472,7 +472,7 @@ func updateQuestionTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -675,7 +675,7 @@ func updateQuestionTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(question).Error
 		if err != nil {
-			t.Errorf("failed to insert question(%s): %w", testCase.description, err)
+			t.Errorf("failed to insert question(%s): %v", testCase.description, err)
 		}
 
 		err = questionImpl.UpdateQuestion(ctx, testCase.after.QuestionnaireID, testCase.after.PageNum, testCase.after.QuestionNum, testCase.after.Type, testCase.after.Body, testCase.after.IsRequired, question.ID)
@@ -695,7 +695,7 @@ func updateQuestionTest(t *testing.T) {
 			Where("id = ?", question.ID).
 			First(&actualQuestion).Error
 		if err != nil {
-			t.Errorf("failed to get question(%s): %w", testCase.description, err)
+			t.Errorf("failed to get question(%s): %v", testCase.description, err)
 		}
 
 		assertion.Equal(testCase.after.QuestionnaireID, actualQuestion.QuestionnaireID, testCase.description, "questionnaire_id")
@@ -740,7 +740,7 @@ func deleteQuestionTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 
@@ -763,7 +763,7 @@ func deleteQuestionTest(t *testing.T) {
 			Session(&gorm.Session{NewDB: true}).
 			Create(question).Error
 		if err != nil {
-			t.Errorf("failed to insert question: %w", err)
+			t.Errorf("failed to insert question: %v", err)
 		}
 	}
 
@@ -805,7 +805,7 @@ func deleteQuestionTest(t *testing.T) {
 			Where("id = ?", testCase.args.questionID).
 			First(&actualQuestion).Error
 		if err != nil {
-			t.Errorf("failed to get question(%s): %w", testCase.description, err)
+			t.Errorf("failed to get question(%s): %v", testCase.description, err)
 		}
 
 		assertion.True(actualQuestion.DeletedAt.Valid, testCase.description, "deleted_at")
@@ -842,7 +842,7 @@ func getQuestionsTest(t *testing.T) {
 			break
 		}
 		if err != nil {
-			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %w", err)
+			t.Errorf("failed to get questionnaire(make invalid questionnaireID): %v", err)
 			break
 		}
 

--- a/model/responses_test.go
+++ b/model/responses_test.go
@@ -125,7 +125,7 @@ func TestInsertResponses(t *testing.T) {
 			Where("response_id = ?", responseID).
 			First(&response).Error
 		if err != nil {
-			t.Errorf("failed to get questionnaire(%s): %w", testCase.description, err)
+			t.Errorf("failed to get questionnaire(%s): %v", testCase.description, err)
 		}
 
 		assertion.Equal(responseID, response.ResponseID, testCase.description, "responseID")
@@ -220,7 +220,7 @@ func TestDeleteResponse(t *testing.T) {
 			Where("response_id = ?", responseID).
 			First(&response).Error
 		if err != nil {
-			t.Errorf("failed to get responses(%s): %w", testCase.description, err)
+			t.Errorf("failed to get responses(%s): %v", testCase.description, err)
 		}
 
 		assertion.WithinDuration(time.Now(), response.DeletedAt.Time, 2*time.Second)


### PR DESCRIPTION
#1046 の対応です
Goのバージョンを1.17から1.20.7に上げました。

`make test`が一部通っていないので、draftです。