### PR TITLE
Bump golang from 1.20.7-alpine to 1.22.2-alpine in /docker/test

### DIFF
--- a/docker/test/Dockerfile
+++ b/docker/test/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.20.7-alpine as builder
+FROM golang:1.22.2-alpine as builder
 RUN apk add --update --no-cache ca-certificates git \
  && apk add --no-cache gcc libc-dev \
  && apk add --no-cache openssl


### PR DESCRIPTION
as titled