### PR TITLE
ステータスコードのチェック

### DIFF
--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -315,6 +315,9 @@ func (q Questionnaire) GetQuestionnaireResponses(c echo.Context, questionnaireID
 	res := []openapi.Response{}
 	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, string(*params.Sort), *params.OnlyMyResponse, userID)
 	if err != nil {
+		if errors.Is(err, model.ErrRecordNotFound) {
+			return res, echo.NewHTTPError(http.StatusNotFound, "respondent not found")
+		}
 		c.Logger().Errorf("failed to get respondent details: %+v", err)
 		return res, echo.NewHTTPError(http.StatusInternalServerError, "failed to get respondent details")
 	}

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -425,6 +425,9 @@ func (q Questionnaire) GetQuestionnaireResult(ctx echo.Context, questionnaireID 
 	params := openapi.GetQuestionnaireResponsesParams{}
 	responses, err := q.GetQuestionnaireResponses(ctx, questionnaireID, params, userID)
 	if err != nil {
+		if errors.Is(echo.ErrNotFound, err) {
+			return openapi.Result{}, err
+		}
 		ctx.Logger().Errorf("failed to get questionnaire responses: %+v", err)
 		return openapi.Result{}, echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaire responses: %w", err))
 	}

--- a/handler/questionnaire.go
+++ b/handler/questionnaire.go
@@ -201,6 +201,9 @@ func (h Handler) GetQuestionnaireResult(ctx echo.Context, questionnaireID openap
 	q := controller.NewQuestionnaire()
 	res, err = q.GetQuestionnaireResult(ctx, questionnaireID, userID)
 	if err != nil {
+		if errors.Is(err, echo.ErrNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Errorf("questionnaire result not found: %w", err))
+		}
 		ctx.Logger().Errorf("failed to get questionnaire result: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaire result: %w", err))
 	}

--- a/handler/questionnaire.go
+++ b/handler/questionnaire.go
@@ -1,11 +1,13 @@
 package handler
 
 import (
+	"errors"
 	"fmt"
 	"net/http"
 
 	"github.com/labstack/echo/v4"
 	"github.com/traPtitech/anke-to/controller"
+	"github.com/traPtitech/anke-to/model"
 	"github.com/traPtitech/anke-to/openapi"
 )
 
@@ -70,6 +72,9 @@ func (h Handler) GetQuestionnaire(ctx echo.Context, questionnaireID openapi.Ques
 	q := controller.NewQuestionnaire()
 	res, err := q.GetQuestionnaire(ctx, questionnaireID)
 	if err != nil {
+		if errors.Is(err, model.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, fmt.Errorf("questionnaire not found: %w", err))
+		}
 		ctx.Logger().Errorf("failed to get questionnaire: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get questionnaire: %w", err))
 	}

--- a/handler/questionnaire.go
+++ b/handler/questionnaire.go
@@ -61,7 +61,7 @@ func (h Handler) PostQuestionnaire(ctx echo.Context) error {
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to post questionnaire: %w", err))
 	}
 
-	return ctx.JSON(200, res)
+	return ctx.JSON(201, res)
 }
 
 // (GET /questionnaires/{questionnaireID})

--- a/handler/questionnaire.go
+++ b/handler/questionnaire.go
@@ -145,6 +145,10 @@ func (h Handler) GetQuestionnaireResponses(ctx echo.Context, questionnaireID ope
 	}
 	q := controller.NewQuestionnaire()
 	res, err := q.GetQuestionnaireResponses(ctx, questionnaireID, params, userID)
+	if err != nil {
+		ctx.Logger().Errorf("failed to get questionnaire responses: %+v", err)
+		return err
+	}
 
 	return ctx.JSON(200, res)
 }

--- a/handler/response.go
+++ b/handler/response.go
@@ -39,7 +39,7 @@ func (h Handler) DeleteResponse(ctx echo.Context, responseID openapi.ResponseIDI
 	err = r.DeleteResponse(ctx, responseID, userID)
 	if err != nil {
 		ctx.Logger().Errorf("failed to delete response: %+v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete response: %w", err))
+		return err
 	}
 
 	return ctx.NoContent(200)

--- a/handler/response.go
+++ b/handler/response.go
@@ -77,5 +77,13 @@ func (h Handler) EditResponse(ctx echo.Context, responseID openapi.ResponseIDInP
 		ctx.Logger().Errorf("failed to validate request body: %+v", err)
 		return echo.NewHTTPError(http.StatusBadRequest, fmt.Errorf("failed to validate request body: %w", err))
 	}
+
+	r := controller.NewResponse()
+	err = r.EditResponse(ctx, responseID, req)
+	if err != nil {
+		ctx.Logger().Errorf("failed to edit response: %+v", err)
+		return err 
+	}
+
 	return ctx.NoContent(200)
 }

--- a/handler/response.go
+++ b/handler/response.go
@@ -53,7 +53,7 @@ func (h Handler) GetResponse(ctx echo.Context, responseID openapi.ResponseIDInPa
 	res, err := r.GetResponse(ctx, responseID)
 	if err != nil {
 		ctx.Logger().Errorf("failed to get response: %+v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to get response: %w", err))
+		return err
 	}
 	return ctx.JSON(200, res)
 }


### PR DESCRIPTION
#1270 
変更箇所
- POST /questionnaires
	- 201を返すように
- GET /questionnaires/{questionnaireID}, GET /questionnaires/{questionnaireID}/responses, GET /questionnaires/{questionnaireID}/result
	- 404を返すように
- GET PATCH DELETE /responses/{responseID}
	- 404, 405を返すように

あと，正規表現を使わなくなったのでopenapiで定義されている GET /questionnaires の503エラーは必要ないと思われます