### PR TITLE
refactor(reminder): replace sort.Slice with google/btree + secondary index

### DIFF
--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -4,31 +4,43 @@ import (
 	"context"
 	"log"
 	"slices"
-	"sort"
 	"sync"
 	"time"
 
+	"github.com/google/btree"
 	"github.com/traPtitech/anke-to/model"
 	"github.com/traPtitech/anke-to/traq"
-	// "golang.org/x/sync/semaphore"
 )
 
 type Job struct {
 	Timestamp       time.Time
 	QuestionnaireID int
+	TimingIndex     int
 	Action          func()
 }
 
 type Reminder struct {
-	jobs     []*Job
+	tree     *btree.BTreeG[*Job]
+	index    map[int][]*Job
 	mu       sync.Mutex
 	Wg       sync.WaitGroup
 	wakeUpCh chan struct{}
 }
 
+func jobLess(a, b *Job) bool {
+	if !a.Timestamp.Equal(b.Timestamp) {
+		return a.Timestamp.Before(b.Timestamp)
+	}
+	if a.QuestionnaireID != b.QuestionnaireID {
+		return a.QuestionnaireID < b.QuestionnaireID
+	}
+	return a.TimingIndex < b.TimingIndex
+}
+
 func NewReminder() *Reminder {
 	return &Reminder{
-		jobs:     []*Job{},
+		tree:     btree.NewG(32, jobLess),
+		index:    make(map[int][]*Job),
 		mu:       sync.Mutex{},
 		Wg:       sync.WaitGroup{},
 		wakeUpCh: make(chan struct{}, 1),
@@ -36,7 +48,6 @@ func NewReminder() *Reminder {
 }
 
 var (
-	// sem                   = semaphore.NewWeighted(1)
 	reminderTimingMinutes = []int{5, 30, 60, 1440, 10080}
 	reminderTimingStrings = []string{"5分", "30分", "1時間", "1日", "1週間"}
 )
@@ -92,7 +103,6 @@ func (re *Reminder) ReminderWorker() {
 }
 
 func (re *Reminder) PushReminder(questionnaireID int, limit *time.Time) error {
-
 	for i := range reminderTimingMinutes {
 		timing := reminderTimingMinutes[i]
 		timingStrings := reminderTimingStrings[i]
@@ -101,6 +111,7 @@ func (re *Reminder) PushReminder(questionnaireID int, limit *time.Time) error {
 			re.push(&Job{
 				Timestamp:       remindTimeStamp,
 				QuestionnaireID: questionnaireID,
+				TimingIndex:     i,
 				Action: func() {
 					err := reminderAction(questionnaireID, timingStrings)
 					if err != nil {
@@ -110,26 +121,21 @@ func (re *Reminder) PushReminder(questionnaireID int, limit *time.Time) error {
 			})
 		}
 	}
-
 	return nil
 }
 
 func (re *Reminder) DeleteReminder(questionnaireID int) error {
 	re.mu.Lock()
-
-	newJobs := []*Job{}
-	removed := false
-	for _, job := range re.jobs {
-		if job.QuestionnaireID != questionnaireID {
-			newJobs = append(newJobs, job)
-			continue
+	jobs, exists := re.index[questionnaireID]
+	if exists {
+		for _, job := range jobs {
+			re.tree.Delete(job)
 		}
-		removed = true
+		delete(re.index, questionnaireID)
 	}
-	re.jobs = newJobs
 	re.mu.Unlock()
 
-	if removed {
+	if exists {
 		re.notifyWorker()
 	}
 
@@ -139,20 +145,14 @@ func (re *Reminder) DeleteReminder(questionnaireID int) error {
 func (re *Reminder) CheckRemindStatus(questionnaireID int) (bool, error) {
 	re.mu.Lock()
 	defer re.mu.Unlock()
-	for _, job := range re.jobs {
-		if job.QuestionnaireID == questionnaireID {
-			return true, nil
-		}
-	}
-	return false, nil
+	jobs, exists := re.index[questionnaireID]
+	return exists && len(jobs) > 0, nil
 }
 
 func (re *Reminder) push(job *Job) {
 	re.mu.Lock()
-	re.jobs = append(re.jobs, job)
-	sort.Slice(re.jobs, func(i, j int) bool {
-		return re.jobs[i].Timestamp.Before(re.jobs[j].Timestamp)
-	})
+	re.tree.ReplaceOrInsert(job)
+	re.index[job.QuestionnaireID] = append(re.index[job.QuestionnaireID], job)
 	re.mu.Unlock()
 
 	re.notifyWorker()
@@ -161,24 +161,35 @@ func (re *Reminder) push(job *Job) {
 func (re *Reminder) peek() *Job {
 	re.mu.Lock()
 	defer re.mu.Unlock()
-	if len(re.jobs) == 0 {
+	min, ok := re.tree.Min()
+	if !ok {
 		return nil
 	}
-	return re.jobs[0]
+	return min
 }
 
 func (re *Reminder) popDue(now time.Time) *Job {
 	re.mu.Lock()
 	defer re.mu.Unlock()
-	if len(re.jobs) == 0 {
+	min, ok := re.tree.Min()
+	if !ok {
 		return nil
 	}
-	if re.jobs[0].Timestamp.After(now) {
+	if min.Timestamp.After(now) {
 		return nil
 	}
-	job := re.jobs[0]
-	re.jobs = re.jobs[1:]
-	return job
+	re.tree.DeleteMin()
+	jobs := re.index[min.QuestionnaireID]
+	for i, j := range jobs {
+		if j == min {
+			re.index[min.QuestionnaireID] = append(jobs[:i], jobs[i+1:]...)
+			break
+		}
+	}
+	if len(re.index[min.QuestionnaireID]) == 0 {
+		delete(re.index, min.QuestionnaireID)
+	}
+	return min
 }
 
 func (re *Reminder) notifyWorker() {

--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -161,35 +161,35 @@ func (re *Reminder) push(job *Job) {
 func (re *Reminder) peek() *Job {
 	re.mu.Lock()
 	defer re.mu.Unlock()
-	min, ok := re.tree.Min()
+	earliest, ok := re.tree.Min()
 	if !ok {
 		return nil
 	}
-	return min
+	return earliest
 }
 
 func (re *Reminder) popDue(now time.Time) *Job {
 	re.mu.Lock()
 	defer re.mu.Unlock()
-	min, ok := re.tree.Min()
+	earliest, ok := re.tree.Min()
 	if !ok {
 		return nil
 	}
-	if min.Timestamp.After(now) {
+	if earliest.Timestamp.After(now) {
 		return nil
 	}
 	re.tree.DeleteMin()
-	jobs := re.index[min.QuestionnaireID]
+	jobs := re.index[earliest.QuestionnaireID]
 	for i, j := range jobs {
-		if j == min {
-			re.index[min.QuestionnaireID] = append(jobs[:i], jobs[i+1:]...)
+		if j == earliest {
+			re.index[earliest.QuestionnaireID] = append(jobs[:i], jobs[i+1:]...)
 			break
 		}
 	}
-	if len(re.index[min.QuestionnaireID]) == 0 {
-		delete(re.index, min.QuestionnaireID)
+	if len(re.index[earliest.QuestionnaireID]) == 0 {
+		delete(re.index, earliest.QuestionnaireID)
 	}
-	return min
+	return earliest
 }
 
 func (re *Reminder) notifyWorker() {

--- a/controller/reminder_test.go
+++ b/controller/reminder_test.go
@@ -455,10 +455,10 @@ func TestPop(t *testing.T) {
 		re.popDue(time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC))
 		assertion.Equal(testCase.expect.num, re.tree.Len(), testCase.description, "queue length")
 		if testCase.expect.num != 0 {
-			min, ok := re.tree.Min()
+			earliest, ok := re.tree.Min()
 			assertion.True(ok)
-			assertion.Equal(jobs[3-testCase.expect.num].Timestamp, min.Timestamp, testCase.description, "first content timestamp")
-			assertion.Equal(jobs[3-testCase.expect.num].QuestionnaireID, min.QuestionnaireID, testCase.description, "first content questionnaire id")
+			assertion.Equal(jobs[3-testCase.expect.num].Timestamp, earliest.Timestamp, testCase.description, "first content timestamp")
+			assertion.Equal(jobs[3-testCase.expect.num].QuestionnaireID, earliest.QuestionnaireID, testCase.description, "first content questionnaire id")
 		}
 	}
 }

--- a/controller/reminder_test.go
+++ b/controller/reminder_test.go
@@ -9,6 +9,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// nthJob returns the nth job (0-indexed) from the btree in ascending order.
+func nthJob(re *Reminder, n int) *Job {
+	var result *Job
+	i := 0
+	re.tree.Ascend(func(item *Job) bool {
+		if i == n {
+			result = item
+			return false
+		}
+		i++
+		return true
+	})
+	return result
+}
+
 func TestPushReminder(t *testing.T) {
 	t.Parallel()
 
@@ -105,7 +120,7 @@ func TestPushReminder(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		assertion.Equal(testCase.expect.num, len(re.jobs), "reminder num")
+		assertion.Equal(testCase.expect.num, re.tree.Len(), "reminder num")
 	}
 }
 
@@ -169,7 +184,7 @@ func TestDeleteReminder(t *testing.T) {
 		require.NoError(t, err)
 		err = re.PushReminder(3, &reminderLimit3)
 		require.NoError(t, err)
-		jobsNum := len(re.jobs)
+		jobsNum := re.tree.Len()
 		err = re.DeleteReminder(testCase.args.questionnaireID)
 		if !testCase.expect.isErr {
 			assertion.NoError(err, testCase.description, "no error")
@@ -181,7 +196,7 @@ func TestDeleteReminder(t *testing.T) {
 		if err != nil {
 			continue
 		}
-		assertion.Equal(jobsNum-testCase.expect.num, len(re.jobs), testCase.description, "reminder num")
+		assertion.Equal(jobsNum-testCase.expect.num, re.tree.Len(), testCase.description, "reminder num")
 	}
 }
 func TestCheckRemindStatus(t *testing.T) {
@@ -365,9 +380,10 @@ func TestPush(t *testing.T) {
 
 	for i, testCase := range testCases {
 		re.push(testCase.args.job)
-		assertion.Equal(i, len(re.jobs)-1, "queue length")
-		assertion.Equal(testCase.args.job.Timestamp, re.jobs[testCase.expect.position].Timestamp, testCase.description, "pushed position timestamp")
-		assertion.Equal(testCase.args.job.QuestionnaireID, re.jobs[testCase.expect.position].QuestionnaireID, testCase.description, "pushed position questionnaire id")
+		assertion.Equal(i, re.tree.Len()-1, "queue length")
+		got := nthJob(re, testCase.expect.position)
+		assertion.Equal(testCase.args.job.Timestamp, got.Timestamp, testCase.description, "pushed position timestamp")
+		assertion.Equal(testCase.args.job.QuestionnaireID, got.QuestionnaireID, testCase.description, "pushed position questionnaire id")
 	}
 }
 
@@ -437,10 +453,12 @@ func TestPop(t *testing.T) {
 
 	for _, testCase := range testCases {
 		re.popDue(time.Date(2003, 1, 1, 0, 0, 0, 0, time.UTC))
-		assertion.Equal(testCase.expect.num, len(re.jobs), testCase.description, "queue length")
+		assertion.Equal(testCase.expect.num, re.tree.Len(), testCase.description, "queue length")
 		if testCase.expect.num != 0 {
-			assertion.Equal(jobs[3-testCase.expect.num].Timestamp, re.jobs[0].Timestamp, testCase.description, "first content timestamp")
-			assertion.Equal(jobs[3-testCase.expect.num].QuestionnaireID, re.jobs[0].QuestionnaireID, testCase.description, "first content questionnaire id")
+			min, ok := re.tree.Min()
+			assertion.True(ok)
+			assertion.Equal(jobs[3-testCase.expect.num].Timestamp, min.Timestamp, testCase.description, "first content timestamp")
+			assertion.Equal(jobs[3-testCase.expect.num].QuestionnaireID, min.QuestionnaireID, testCase.description, "first content questionnaire id")
 		}
 	}
 }

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/traPtitech/anke-to
 go 1.25.7
 
 require (
+	github.com/google/btree v1.1.3
 	github.com/google/subcommands v1.2.0 // indirect
 	github.com/google/wire v0.6.0
 	github.com/labstack/echo/v4 v4.13.3

--- a/go.sum
+++ b/go.sum
@@ -137,6 +137,8 @@ github.com/golang/protobuf v1.5.2/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiu
 github.com/golang/protobuf v1.5.3/go.mod h1:XVQd3VNwM+JqD3oG2Ue2ip4fOMUkwXdXDdiuN0vRsmY=
 github.com/google/btree v0.0.0-20180813153112-4030bb1f1f0c/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
 github.com/google/btree v1.0.0/go.mod h1:lNA+9X1NB3Zf8V7Ke586lFgjr2dZNuvo3lPJSGZ5JPQ=
+github.com/google/btree v1.1.3 h1:CVpQJjYgC4VbzxeGVHfvZrv1ctoYCAI8vbl07Fcxlyg=
+github.com/google/btree v1.1.3/go.mod h1:qOPhT0dTNdNzV6Z/lhRX0YXUafgPLFUh+gZMl761Gm4=
 github.com/google/go-cmp v0.2.0/go.mod h1:oXzfMopK8JAjlY9xF4vHSVASa0yLyX7SntLO5aqRK0M=
 github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/google/go-cmp v0.3.1/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=


### PR DESCRIPTION
## Summary

- `push()` の度に走っていた O(n log n) の `sort.Slice` を `github.com/google/btree`（`BTreeG[*Job]`）に置き換え、push/peek/pop をすべて O(log n) に改善
- questionnaireID をキーとした補助インデックス `map[int][]*Job` を追加し、`DeleteReminder` を O(n) フルスキャンから O(k log n)（k≤5）に改善
- `CheckRemindStatus` も index map の lookup のみで O(1) に改善
- `Job` に `TimingIndex int` を追加し、同一 questionnaire の 5 つの job が btree 上で一意のキーを持つことを保証

## 複雑度の変化

| 操作 | 変更前 | 変更後 |
|---|---|---|
| Push | O(n log n) | O(log n) |
| Peek | O(1) | O(1) |
| Pop | O(n) | O(log n) |
| DeleteReminder | O(n) | O(k log n), k≤5 |
| CheckRemindStatus | O(n) | O(1) |

## 依存関係

`github.com/google/btree v1.1.3` を追加。`go get github.com/google/btree@v1.1.3` または `go mod tidy` で取得してください。

## Test plan

- [x] `go get github.com/google/btree@v1.1.3 && go mod tidy` で依存解決
- [x] `go test ./controller/... -run TestPushReminder` が通ること
- [x] `go test ./controller/... -run TestDeleteReminder` が通ること
- [x] `go test ./controller/... -run TestCheckRemindStatus` が通ること
- [x] `go test ./controller/... -run TestPush` が通ること
- [x] `go test ./controller/... -run TestPop` が通ること
- [x] `go test ./controller/... -run TestReminderWorkerReschedulesEarlierJob` が通ること