### PR TITLE
Wrap response deletion in transaction for data consistency

### DIFF
--- a/controller/response.go
+++ b/controller/response.go
@@ -151,13 +151,21 @@ func (r *Response) DeleteResponse(ctx echo.Context, responseID openapi.ResponseI
 		return echo.NewHTTPError(http.StatusMethodNotAllowed, fmt.Errorf("unable delete the expired response"))
 	}
 
-	err = r.IRespondent.DeleteRespondent(ctx.Request().Context(), responseID)
-	if err != nil {
-		ctx.Logger().Errorf("failed to delete respondent: %+v", err)
-		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete respondent: %w", err))
-	}
+	err = r.ITransaction.Do(ctx.Request().Context(), nil, func(c context.Context) error {
+		err := r.IRespondent.DeleteRespondent(c, responseID)
+		if err != nil {
+			ctx.Logger().Errorf("failed to delete respondent: %+v", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete respondent: %w", err))
+		}
 
-	err = r.IResponse.DeleteResponse(ctx.Request().Context(), responseID)
+		err = r.IResponse.DeleteResponse(c, responseID)
+		if err != nil {
+			ctx.Logger().Errorf("failed to delete response: %+v", err)
+			return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete response: %w", err))
+		}
+
+		return nil
+	})
 	if err != nil {
 		ctx.Logger().Errorf("failed to delete response: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("failed to delete response: %w", err))


### PR DESCRIPTION
## Summary
Refactored the `DeleteResponse` method to wrap both respondent and response deletion operations in a database transaction, ensuring data consistency and atomicity.

## Key Changes
- Wrapped `DeleteRespondent` and `DeleteResponse` calls within `ITransaction.Do()` to execute them as a single atomic operation
- Both deletion operations now share the same transaction context, ensuring either both succeed or both fail together
- Maintained existing error handling and logging for each operation within the transaction

## Implementation Details
- The transaction callback receives a context parameter that is passed to both deletion methods
- Error handling remains consistent with the original implementation, with appropriate HTTP 500 responses for failures
- The transaction ensures data integrity by preventing partial deletions where a respondent is deleted but the response remains (or vice versa)