### PR TITLE
fix: scale label nil dereference, out of bounds panic, and error handling bugs

### DIFF
--- a/controller/adapter.go
+++ b/controller/adapter.go
@@ -3,6 +3,7 @@ package controller
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sort"
 	"strconv"
 
@@ -158,6 +159,9 @@ func convertQuestions(questions []model.Questions) ([]openapi.Question, error) {
 			question.ScaleLabels, err = model.NewScaleLabel().GetScaleLabels(context.Background(), []int{question.ID})
 			if err != nil {
 				return nil, err
+			}
+			if len(question.ScaleLabels) == 0 {
+				return nil, fmt.Errorf("scale label not found for question %d", question.ID)
 			}
 			err = q.FromQuestionSettingsScale(
 				openapi.QuestionSettingsScale{

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -717,10 +717,18 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 						c.Logger().Errorf("invalid scale")
 						return errors.New("invalid scale")
 					}
+					minLabel := ""
+					maxLabel := ""
+					if b.MinLabel != nil {
+						minLabel = *b.MinLabel
+					}
+					if b.MaxLabel != nil {
+						maxLabel = *b.MaxLabel
+					}
 					err = q.IScaleLabel.InsertScaleLabel(ctx, questionID,
 						model.ScaleLabels{
-							ScaleLabelLeft:  *b.MinLabel,
-							ScaleLabelRight: *b.MaxLabel,
+							ScaleLabelLeft:  minLabel,
+							ScaleLabelRight: maxLabel,
 							ScaleMax:        b.MaxValue,
 							ScaleMin:        b.MinValue,
 						})
@@ -1158,7 +1166,7 @@ func (q *Questionnaire) PostQuestionnaireResponse(c echo.Context, questionnaireI
 	// 回答期限を過ぎていたらエラー
 	if limit.Valid && limit.Time.Before(time.Now()) {
 		c.Logger().Info("expired questionnaire")
-		return res, echo.NewHTTPError(http.StatusUnprocessableEntity, err)
+		return res, echo.NewHTTPError(http.StatusUnprocessableEntity, errors.New("expired questionnaire"))
 	}
 
 	questions, err := q.IQuestion.GetQuestions(c.Request().Context(), questionnaireID)
@@ -1253,7 +1261,8 @@ func (q *Questionnaire) PostQuestionnaireResponse(c echo.Context, questionnaireI
 			if !params.IsDraft {
 				label, ok := scaleLabelMap[responseMeta.QuestionID]
 				if !ok {
-					label = model.ScaleLabels{}
+					c.Logger().Errorf("scale label not found for question %d", responseMeta.QuestionID)
+					return res, echo.NewHTTPError(http.StatusInternalServerError, fmt.Errorf("scale label not found for question %d", responseMeta.QuestionID))
 				}
 				err := q.IScaleLabel.CheckScaleLabel(label, responseMeta.Data)
 				if err != nil {


### PR DESCRIPTION
## 概要

コードレビューで発見した4つのバグを修正します。いずれも `controller/` 層のスケールラベル処理および回答投稿処理に関するものです。

---

## 修正内容

### 🔴 Bug 1: `EditQuestionnaire` での nil ポインタ逆参照（`controller/questionnaire.go`）

`EditQuestionnaire` でアンケート編集時に新しい LinearScale 質問を追加する際、`MinLabel` / `MaxLabel`（`*string` 型、任意フィールド）を nil チェックなしに直接逆参照していました。

`PostQuestionnaire` では同じ処理に nil チェックが存在していましたが、`EditQuestionnaire` 側だけ漏れており、ラベル未指定のリクエストでパニックが発生していました。

**修正:** `PostQuestionnaire` と同様に nil チェックを追加し、nil の場合は空文字列にフォールバックするよう修正。

---

### 🔴 Bug 2: `convertQuestions` でのスライス境界外アクセス（`controller/adapter.go`）

`convertQuestions` の LinearScale 処理で、`GetScaleLabels` の結果を長さ確認なしに `ScaleLabels[0]` へアクセスしていました。

DBのデータ不整合等でスケールラベルが存在しない場合、空スライスへのインデックスアクセスによりパニックが発生していました。

**修正:** スライスの長さを確認し、0件の場合はエラーを返すよう修正。

---

### 🟠 Bug 3: スケール検証フォールバックの誤り（`controller/questionnaire.go`）

回答投稿時のスケール値検証で、DBにスケールラベルが見つからない場合に `ScaleLabels{}` のゼロ値（`ScaleMin=0`, `ScaleMax=0`）でフォールバックしていました。

`CheckScaleLabel` はこの値を境界として使用するため、0 以外の全回答値が不正として弾かれ、クライアントに誤った HTTP 400 が返されていました（実際にはサーバー側のデータ不整合が原因）。

**修正:** ラベルが見つからない場合は HTTP 500 を返すよう修正。

---

### 🟡 Bug 4: `nil` エラーを `echo.NewHTTPError` に渡す（`controller/questionnaire.go`）

`PostQuestionnaireResponse` の回答期限チェックで、`err` が `nil` の状態で `echo.NewHTTPError(http.StatusUnprocessableEntity, err)` を呼び出していました。結果として HTTP 422 のレスポンスボディが空になっていました。

**修正:** `errors.New("expired questionnaire")` を渡すよう修正。

---

## 変更ファイル

- `controller/adapter.go`
- `controller/questionnaire.go`