### PR TITLE
Skip CI for auto-generated file commits

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
           files=(openapi/server.go openapi/spec.go openapi/types.go wire_gen.go)
           if ! git diff --quiet -- "${files[@]}"; then
             git add "${files[@]}"
-            git commit -m "chore: regenerate generated files"
+            git commit -m "chore: regenerate generated files [skip ci]"
             git push origin HEAD:${{ github.head_ref }}
           fi
       - name: Verify generated files are committed


### PR DESCRIPTION
## Summary
Updated the GitHub Actions workflow to prevent CI from running on commits that automatically regenerate generated files.

## Key Changes
- Added `[skip ci]` flag to the git commit message for auto-generated files
  - This prevents unnecessary CI pipeline runs when only generated files (openapi/server.go, openapi/spec.go, openapi/types.go, wire_gen.go) are updated
  - Reduces CI overhead and improves workflow efficiency

## Implementation Details
The `[skip ci]` directive is a standard GitHub Actions convention that skips workflow execution when included in a commit message. This is appropriate for auto-generated files that don't require validation since they are deterministically produced by code generation tools.