### PR TITLE
未公開のアンケートのリマインダーを停止する

### DIFF
--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -470,7 +470,7 @@ func (q *Questionnaire) PostQuestionnaire(c echo.Context, params openapi.PostQue
 			append(allTargetUsers, targetGroupNames...),
 		)
 
-		if params.ResponseDueDateTime != nil {
+		if params.ResponseDueDateTime != nil && params.IsPublished {
 			dueDateTime := responseDueDateTime.Time
 			err = q.PushReminder(questionnaireID, &dueDateTime)
 			if err != nil {
@@ -922,7 +922,7 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 			c.Logger().Errorf("failed to delete reminder: %+v", err)
 			return err
 		}
-		if params.ResponseDueDateTime != nil {
+		if params.ResponseDueDateTime != nil && params.IsPublished {
 			dueDateTime := responseDueDateTime.Time
 			err = q.PushReminder(questionnaireID, &dueDateTime)
 			if err != nil {

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -1004,6 +1004,30 @@ func TestPostQuestionnaire(t *testing.T) {
 			},
 		},
 		{
+			description: "not published with response due date time",
+			args: args{
+				params: openapi.PostQuestionnaireJSONRequestBody{
+					Admin:                    sampleAdmin,
+					Description:              "第1回集会らん☆ぷろ参加者募集",
+					IsDuplicateAnswerAllowed: true,
+					IsAnonymous:              false,
+					IsPublished:              false,
+					Questions: []openapi.NewQuestion{
+						sampleQuestionSettingsText,
+						sampleQuestionSettingsTextLong,
+						sampleQuestionSettingsNumber,
+						sampleQuestionSettingsSingleChoice,
+						sampleQuestionSettingsMultipleChoice,
+						sampleQeustionsettingsScale,
+					},
+					ResponseDueDateTime: &responseDueDateTimePlus,
+					ResponseViewableBy:  "anyone",
+					Target:              sampleTarget,
+					Title:               "第1回集会らん☆ぷろ募集アンケート",
+				},
+			},
+		},
+		{
 			description: "invalid question settings number",
 			args: args{
 				params: openapi.PostQuestionnaireJSONRequestBody{
@@ -1640,6 +1664,31 @@ func TestEditQuestionnaire(t *testing.T) {
 						sampleQeustionsettingsScale,
 					},
 					ResponseDueDateTime: nil,
+					ResponseViewableBy:  "anyone",
+					Target:              sampleTarget,
+					Title:               "第1回集会らん☆ぷろ募集アンケート",
+				},
+				isNewQuestion: []bool{false, false, false, false, false, false},
+			},
+		},
+		{
+			description: "not published with response due date time",
+			args: args{
+				params: openapi.PostQuestionnaireJSONRequestBody{
+					Admin:                    sampleAdmin,
+					Description:              "第1回集会らん☆ぷろ参加者募集",
+					IsDuplicateAnswerAllowed: true,
+					IsAnonymous:              false,
+					IsPublished:              false,
+					Questions: []openapi.NewQuestion{
+						sampleQuestionSettingsText,
+						sampleQuestionSettingsTextLong,
+						sampleQuestionSettingsNumber,
+						sampleQuestionSettingsSingleChoice,
+						sampleQuestionSettingsMultipleChoice,
+						sampleQeustionsettingsScale,
+					},
+					ResponseDueDateTime: &responseDueDateTimePlus,
 					ResponseViewableBy:  "anyone",
 					Target:              sampleTarget,
 					Title:               "第1回集会らん☆ぷろ募集アンケート",

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -655,12 +655,16 @@ func TestPostQuestionnaire(t *testing.T) {
 		isErr             bool
 		err               error
 		normalizedDueDate bool
+		hasReminder       *bool
 	}
 	type test struct {
 		description string
 		args
 		expect
 	}
+
+	hasReminderTrue := true
+	hasReminderFalse := false
 
 	responseDueDateTimeMinus := time.Now().Add(-24 * time.Hour)
 	responseDueDateTimeNearlyNowPast := time.Now().Add(-3 * time.Second)
@@ -722,6 +726,9 @@ func TestPostQuestionnaire(t *testing.T) {
 					Target:              sampleTarget,
 					Title:               "第1回集会らん☆ぷろ募集アンケート",
 				},
+			},
+			expect: expect{
+				hasReminder: &hasReminderTrue,
 			},
 		},
 		{
@@ -1026,6 +1033,9 @@ func TestPostQuestionnaire(t *testing.T) {
 					Title:               "第1回集会らん☆ぷろ募集アンケート",
 				},
 			},
+			expect: expect{
+				hasReminder: &hasReminderFalse,
+			},
 		},
 		{
 			description: "invalid question settings number",
@@ -1177,6 +1187,12 @@ func TestPostQuestionnaire(t *testing.T) {
 		assertion.Equal(testCase.args.params.Target.Groups, questionnaireDetail.Target.Groups, "target groups not equal")
 
 		assertion.Equal(testCase.args.params.Title, questionnaireDetail.Title, "title not equal")
+
+		if testCase.expect.hasReminder != nil {
+			remindStatus, err := re.CheckRemindStatus(questionnaireDetail.QuestionnaireId)
+			assertion.NoError(err, testCase.description, "no error checking remind status")
+			assertion.Equal(*testCase.expect.hasReminder, remindStatus, testCase.description, "reminder status")
+		}
 	}
 }
 
@@ -1284,14 +1300,18 @@ func TestEditQuestionnaire(t *testing.T) {
 		isNewQuestion             []bool
 	}
 	type expect struct {
-		isErr bool
-		err   error
+		isErr       bool
+		err         error
+		hasReminder *bool
 	}
 	type test struct {
 		description string
 		args
 		expect
 	}
+
+	hasReminderTrue := true
+	hasReminderFalse := false
 
 	responseDueDateTimeMinus := time.Now().Add(-24 * time.Hour)
 	responseDueDateTimePlus := time.Now().Add(24 * time.Hour)
@@ -1385,6 +1405,9 @@ func TestEditQuestionnaire(t *testing.T) {
 					Title:               "第1回集会らん☆ぷろ募集アンケート",
 				},
 				isNewQuestion: []bool{false, false, false, false, false, false},
+			},
+			expect: expect{
+				hasReminder: &hasReminderTrue,
 			},
 		},
 		{
@@ -1695,6 +1718,9 @@ func TestEditQuestionnaire(t *testing.T) {
 				},
 				isNewQuestion: []bool{false, false, false, false, false, false},
 			},
+			expect: expect{
+				hasReminder: &hasReminderFalse,
+			},
 		},
 		{
 			description: "invalid question settings number",
@@ -1904,6 +1930,12 @@ func TestEditQuestionnaire(t *testing.T) {
 			questionnaireDetailExpected.Questions[i].CreatedAt = questionnaireDetailEdited.Questions[i].CreatedAt
 		}
 		assertion.Equal(questionnaireDetailExpected, questionnaireDetailEdited, testCase.description, "questionnaireDetail")
+
+		if testCase.expect.hasReminder != nil {
+			remindStatus, err := re.CheckRemindStatus(questionnaireDetail.QuestionnaireId)
+			assertion.NoError(err, testCase.description, "no error checking remind status")
+			assertion.Equal(*testCase.expect.hasReminder, remindStatus, testCase.description, "reminder status")
+		}
 	}
 }
 

--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -206,6 +206,10 @@ func reminderAction(questionnaireID int, leftTimeText string) error {
 		return err
 	}
 
+	if !questionnaire.IsPublished {
+		return nil
+	}
+
 	reminderTargetOverrides, err := model.NewReminderTarget().GetReminderTargets(ctx, questionnaireID)
 	if err != nil {
 		return err

--- a/controller/reminder_test.go
+++ b/controller/reminder_test.go
@@ -1,12 +1,18 @@
 package controller
 
 import (
+	"bytes"
+	"encoding/json"
 	"errors"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
+	"github.com/labstack/echo/v4"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/traPtitech/anke-to/openapi"
 )
 
 // nthJob returns the nth job (0-indexed) from the btree in ascending order.
@@ -461,4 +467,34 @@ func TestPop(t *testing.T) {
 			assertion.Equal(jobs[3-testCase.expect.num].QuestionnaireID, earliest.QuestionnaireID, testCase.description, "first content questionnaire id")
 		}
 	}
+}
+
+func TestReminderActionUnpublished(t *testing.T) {
+	responseDueDateTimePlus := time.Now().Add(24 * time.Hour)
+	params := openapi.PostQuestionnaireJSONRequestBody{
+		Admin:                    sampleAdmin,
+		Description:              "リマインダーテスト用アンケート",
+		IsDuplicateAnswerAllowed: false,
+		IsAnonymous:              false,
+		IsPublished:              false,
+		Questions:                []openapi.NewQuestion{},
+		ResponseDueDateTime:      &responseDueDateTimePlus,
+		ResponseViewableBy:       "anyone",
+		Target:                   sampleTarget,
+		Title:                    "未公開リマインダーテスト",
+	}
+
+	e := echo.New()
+	body, err := json.Marshal(params)
+	require.NoError(t, err)
+	req := httptest.NewRequest(http.MethodPost, "/questionnaires", bytes.NewReader(body))
+	rec := httptest.NewRecorder()
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	ctx := e.NewContext(req, rec)
+
+	detail, err := q.PostQuestionnaire(ctx, params)
+	require.NoError(t, err)
+
+	err = reminderAction(detail.QuestionnaireId, "5分")
+	assert.NoError(t, err, "reminderAction should return nil for unpublished questionnaire")
 }


### PR DESCRIPTION
## 概要

アンケートが未公開（`is_published = false`）の場合に、リマインダーが送信されないようにしました。

## 変更内容

- `PostQuestionnaire` および `EditQuestionnaire` において、アンケートが公開されていない場合はリマインダーをスケジュールしないように修正
- `reminderAction` において、リマインダー実行時にアンケートが未公開であれば早期リターンするように修正（キューに残っているリマインダーへの安全策）

## 背景

これまでは、`is_published` の状態に関わらずリマインダーがスケジュール・送信されていました。そのため、未公開のアンケートに対してもリマインダーが送られてしまう問題がありました。

今回の修正では以下の2点で対応しています：

1. **スケジューリング時のチェック**: アンケートの作成・編集時に `is_published` が `false` の場合はリマインダーをキューに追加しない
2. **実行時のチェック**: リマインダーが実行される時点でもアンケートの公開状態を確認し、未公開であればリマインダーの送信をスキップする