### PR TITLE
アンケート一覧APIのresponse_viewable_byが空文字列になるバグを修正

### DIFF
--- a/controller/adapter.go
+++ b/controller/adapter.go
@@ -28,6 +28,7 @@ func questionnaireInfo2questionnaireSummary(questionnaireInfo model.Questionnair
 		IsTargetingMe:            questionnaireInfo.IsTargeted,
 		ModifiedAt:               questionnaireInfo.ModifiedAt,
 		QuestionnaireId:          questionnaireInfo.ID,
+		ResponseViewableBy:       convertResSharedTo(questionnaireInfo.ResSharedTo),
 		Title:                    questionnaireInfo.Title,
 	}
 	if respondedDateTimeByMe.Valid {


### PR DESCRIPTION
## 概要

`GET /api/questionnaires` が `response_viewable_by` を空文字列で返していたバグを修正しました。

## 原因

`controller/adapter.go` の `questionnaireInfo2questionnaireSummary` 関数で、`ResponseViewableBy` フィールドのセットが抜けていました。

`questionnaire2QuestionnaireDetail` では `convertResSharedTo(questionnaires.ResSharedTo)` を使って正しくセットしているのに対し、`questionnaireInfo2questionnaireSummary` では同フィールドが設定されていないため、ゼロ値（空文字列）が返されていました。

## 修正内容

`questionnaireInfo2questionnaireSummary` に以下の1行を追加しました：

```go
ResponseViewableBy: convertResSharedTo(questionnaireInfo.ResSharedTo),
```