### PR TITLE
非推奨の middleware.Logger を RequestLogger に置き換え

### DIFF
--- a/main.go
+++ b/main.go
@@ -43,20 +43,7 @@ func main() {
 
 	api.Reminder.Wg.Add(1)
 	go func() {
-		e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
-			LogStatus:   true,
-			LogURI:      true,
-			LogMethod:   true,
-			LogLatency:  true,
-			LogRemoteIP: true,
-			LogError:    true,
-			HandleError: true,
-			LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
-				e.Logger.Infof("method=%s uri=%s status=%d latency=%s ip=%s",
-					v.Method, v.URI, v.Status, v.Latency, v.RemoteIP)
-				return nil
-			},
-		}))
+		e.Use(middleware.RequestLogger())
 		e.Use(middleware.Recover())
 
 		swagger, err := openapi.GetSwagger()

--- a/main.go
+++ b/main.go
@@ -43,7 +43,20 @@ func main() {
 
 	api.Reminder.Wg.Add(1)
 	go func() {
-		e.Use(middleware.Logger())
+		e.Use(middleware.RequestLoggerWithConfig(middleware.RequestLoggerConfig{
+			LogStatus:   true,
+			LogURI:      true,
+			LogMethod:   true,
+			LogLatency:  true,
+			LogRemoteIP: true,
+			LogError:    true,
+			HandleError: true,
+			LogValuesFunc: func(c echo.Context, v middleware.RequestLoggerValues) error {
+				e.Logger.Infof("method=%s uri=%s status=%d latency=%s ip=%s",
+					v.Method, v.URI, v.Status, v.Latency, v.RemoteIP)
+				return nil
+			},
+		}))
 		e.Use(middleware.Recover())
 
 		swagger, err := openapi.GetSwagger()


### PR DESCRIPTION
## 概要

`middleware.Logger()` が非推奨（deprecated）となったため、`middleware.RequestLogger()` に置き換えます。

## 変更内容

- `main.go` の `middleware.Logger()` を `middleware.RequestLogger()` に1行で置き換え
- ログ出力フィールドは旧 `middleware.Logger()` とほぼ同等（method、uri、status、latency、host、remote_ip、user_agent、bytes_in、bytes_out、request_id）
- 出力形式がJSONからGoの標準ライブラリ `slog` のテキスト形式に変更される（必要であれば `slog.SetDefault(slog.New(slog.NewJSONHandler(os.Stdout, nil)))` でJSON出力に戻せる）

## 背景

`golangci-lint` の staticcheck（SA1019）により、以下の警告が発生していました。

```
SA1019: middleware.Logger is deprecated: please use middleware.RequestLogger or middleware.RequestLoggerWithConfig instead.
```