### PR TITLE
fix: draft response visibility

### DIFF
--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -1130,15 +1130,8 @@ func (q *Questionnaire) GetQuestionnaireResponses(c echo.Context, questionnaireI
 		onlyMyResponse = false
 	}
 	if params.IsDraft != nil && *params.IsDraft && !onlyMyResponse {
-		isAdmin, err := q.IAdministrator.CheckQuestionnaireAdmin(c.Request().Context(), userID, questionnaireID)
-		if err != nil {
-			c.Logger().Errorf("failed to check questionnaire admin: %+v", err)
-			return res, echo.NewHTTPError(http.StatusInternalServerError, "failed to check questionnaire admin")
-		}
-		if !isAdmin {
-			c.Logger().Infof("user %s is not allowed to view other respondents' drafts for questionnaire %d", userID, questionnaireID)
-			return res, echo.NewHTTPError(http.StatusForbidden, "you do not have permission to view other respondents' drafts")
-		}
+		c.Logger().Infof("user %s is not allowed to view other respondents' drafts for questionnaire %d", userID, questionnaireID)
+		return res, echo.NewHTTPError(http.StatusForbidden, "you do not have permission to view other respondents' drafts")
 	}
 	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, sort, onlyMyResponse, userID, params.IsDraft)
 	if err != nil {

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -1129,11 +1129,18 @@ func (q *Questionnaire) GetQuestionnaireResponses(c echo.Context, questionnaireI
 	} else {
 		onlyMyResponse = false
 	}
-	if params.IsDraft != nil && *params.IsDraft && !onlyMyResponse {
+	isDraft := params.IsDraft
+	if !onlyMyResponse {
+		submittedOnly := false
+		if params.IsDraft == nil {
+			isDraft = &submittedOnly
+		}
+	}
+	if isDraft != nil && *isDraft && !onlyMyResponse {
 		c.Logger().Infof("user %s is not allowed to view other respondents' drafts for questionnaire %d", userID, questionnaireID)
 		return res, echo.NewHTTPError(http.StatusForbidden, "you do not have permission to view other respondents' drafts")
 	}
-	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, sort, onlyMyResponse, userID, params.IsDraft)
+	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, sort, onlyMyResponse, userID, isDraft)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {
 			return res, echo.NewHTTPError(http.StatusNotFound, "respondent not found")

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -1129,6 +1129,17 @@ func (q *Questionnaire) GetQuestionnaireResponses(c echo.Context, questionnaireI
 	} else {
 		onlyMyResponse = false
 	}
+	if params.IsDraft != nil && *params.IsDraft && !onlyMyResponse {
+		isAdmin, err := q.IAdministrator.CheckQuestionnaireAdmin(c.Request().Context(), userID, questionnaireID)
+		if err != nil {
+			c.Logger().Errorf("failed to check questionnaire admin: %+v", err)
+			return res, echo.NewHTTPError(http.StatusInternalServerError, "failed to check questionnaire admin")
+		}
+		if !isAdmin {
+			c.Logger().Infof("user %s is not allowed to view other respondents' drafts for questionnaire %d", userID, questionnaireID)
+			return res, echo.NewHTTPError(http.StatusForbidden, "you do not have permission to view other respondents' drafts")
+		}
+	}
 	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, sort, onlyMyResponse, userID, params.IsDraft)
 	if err != nil {
 		if errors.Is(err, model.ErrRecordNotFound) {

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -1129,16 +1129,14 @@ func (q *Questionnaire) GetQuestionnaireResponses(c echo.Context, questionnaireI
 	} else {
 		onlyMyResponse = false
 	}
-	isDraft := params.IsDraft
-	if !onlyMyResponse {
-		submittedOnly := false
-		if params.IsDraft == nil {
-			isDraft = &submittedOnly
-		}
+
+	if params.IsDraft != nil && *params.IsDraft {
+		onlyMyResponse = true
 	}
-	if isDraft != nil && *isDraft && !onlyMyResponse {
-		c.Logger().Infof("user %s is not allowed to view other respondents' drafts for questionnaire %d", userID, questionnaireID)
-		return res, echo.NewHTTPError(http.StatusForbidden, "you do not have permission to view other respondents' drafts")
+	isDraft := params.IsDraft
+	if !onlyMyResponse && isDraft == nil {
+		submittedOnly := false
+		isDraft = &submittedOnly
 	}
 	respondentDetails, err := q.GetRespondentDetails(c.Request().Context(), questionnaireID, sort, onlyMyResponse, userID, isDraft)
 	if err != nil {

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -13,6 +13,7 @@ import (
 	"net/url"
 	"sort"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -49,118 +50,118 @@ var (
 	sampleQuestionSettingsMultipleChoice = openapi.NewQuestion{}
 	sampleQeustionsettingsScale          = openapi.NewQuestion{}
 	sampleQuestionnaire                  = openapi.PostQuestionnaireJSONRequestBody{}
+	sampleQuestionnaireOnce              sync.Once
 )
 
 func setupSampleQuestionnaire() {
-	if sampleQuestionnaire.Title != "" {
-		return
-	}
-	sampleQuestionSettingsText = openapi.NewQuestion{
-		Title:      "質問（テキスト）",
-		IsRequired: true,
-	}
-	sampleQuestionSettingsTextMaxLength := 100
-	err := sampleQuestionSettingsText.FromQuestionSettingsText(openapi.QuestionSettingsText{
-		MaxLength:    &sampleQuestionSettingsTextMaxLength,
-		QuestionType: openapi.QuestionSettingsTextQuestionTypeText,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQuestionSettingsText: %v", err))
-	}
-	sampleQuestionSettingsTextLong = openapi.NewQuestion{
-		Title:      "質問（ロングテキスト）",
-		IsRequired: true,
-	}
-	sampleQuestionSettingsTextLongMaxLength := 500
-	err = sampleQuestionSettingsTextLong.FromQuestionSettingsTextLong(openapi.QuestionSettingsTextLong{
-		MaxLength:    &sampleQuestionSettingsTextLongMaxLength,
-		QuestionType: openapi.QuestionSettingsTextLongQuestionTypeTextLong,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQuestionSettingsTextLong: %v", err))
-	}
-	sampleQuestionSettingsNumber = openapi.NewQuestion{
-		Title:      "質問（数値）",
-		IsRequired: true,
-	}
-	sampleQuestionSettingsNumberMaxValue := 100.5
-	sampleQuestionSettingsNumberMinValue := 0.5
-	err = sampleQuestionSettingsNumber.FromQuestionSettingsNumber(openapi.QuestionSettingsNumber{
-		MaxValue:     &sampleQuestionSettingsNumberMaxValue,
-		MinValue:     &sampleQuestionSettingsNumberMinValue,
-		QuestionType: openapi.QuestionSettingsNumberQuestionTypeNumber,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQuestionSettingsNumber: %v", err))
-	}
-	sampleQuestionSettingsSingleChoice = openapi.NewQuestion{
-		Title:      "質問（単一選択）",
-		IsRequired: true,
-	}
-	err = sampleQuestionSettingsSingleChoice.FromQuestionSettingsSingleChoice(openapi.QuestionSettingsSingleChoice{
-		Options:      []string{"選択肢A", "選択肢B", "選択肢C", "選択肢D"},
-		QuestionType: openapi.QuestionSettingsSingleChoiceQuestionTypeSingleChoice,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQuestionSettingsSingleChoice: %v", err))
-	}
-	sampleQuestionSettingsMultipleChoice = openapi.NewQuestion{
-		Title:      "質問（複数選択）",
-		IsRequired: true,
-	}
-	err = sampleQuestionSettingsMultipleChoice.FromQuestionSettingsMultipleChoice(openapi.QuestionSettingsMultipleChoice{
-		Options:      []string{"選択肢A", "選択肢B", "選択肢C", "選択肢D"},
-		QuestionType: openapi.QuestionSettingsMultipleChoiceQuestionTypeMultipleChoice,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQuestionSettingsMultipleChoice: %v", err))
-	}
-	sampleQeustionsettingsScale = openapi.NewQuestion{
-		Title:      "質問（スケール）",
-		IsRequired: true,
-	}
-	sampleQeustionsettingsScaleMaxLabel := "最大値"
-	sampleQeustionsettingsScaleMinLabel := "最小値"
-	err = sampleQeustionsettingsScale.FromQuestionSettingsScale(openapi.QuestionSettingsScale{
-		MaxLabel:     &sampleQeustionsettingsScaleMaxLabel,
-		MaxValue:     10,
-		MinLabel:     &sampleQeustionsettingsScaleMinLabel,
-		MinValue:     1,
-		QuestionType: openapi.QuestionSettingsScaleQuestionTypeScale,
-	})
-	if err != nil {
-		panic(fmt.Sprintf("failed to setup sampleQeustionsettingsScale: %v", err))
-	}
+	sampleQuestionnaireOnce.Do(func() {
+		sampleQuestionSettingsText = openapi.NewQuestion{
+			Title:      "質問（テキスト）",
+			IsRequired: true,
+		}
+		sampleQuestionSettingsTextMaxLength := 100
+		err := sampleQuestionSettingsText.FromQuestionSettingsText(openapi.QuestionSettingsText{
+			MaxLength:    &sampleQuestionSettingsTextMaxLength,
+			QuestionType: openapi.QuestionSettingsTextQuestionTypeText,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQuestionSettingsText: %v", err))
+		}
+		sampleQuestionSettingsTextLong = openapi.NewQuestion{
+			Title:      "質問（ロングテキスト）",
+			IsRequired: true,
+		}
+		sampleQuestionSettingsTextLongMaxLength := 500
+		err = sampleQuestionSettingsTextLong.FromQuestionSettingsTextLong(openapi.QuestionSettingsTextLong{
+			MaxLength:    &sampleQuestionSettingsTextLongMaxLength,
+			QuestionType: openapi.QuestionSettingsTextLongQuestionTypeTextLong,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQuestionSettingsTextLong: %v", err))
+		}
+		sampleQuestionSettingsNumber = openapi.NewQuestion{
+			Title:      "質問（数値）",
+			IsRequired: true,
+		}
+		sampleQuestionSettingsNumberMaxValue := 100.5
+		sampleQuestionSettingsNumberMinValue := 0.5
+		err = sampleQuestionSettingsNumber.FromQuestionSettingsNumber(openapi.QuestionSettingsNumber{
+			MaxValue:     &sampleQuestionSettingsNumberMaxValue,
+			MinValue:     &sampleQuestionSettingsNumberMinValue,
+			QuestionType: openapi.QuestionSettingsNumberQuestionTypeNumber,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQuestionSettingsNumber: %v", err))
+		}
+		sampleQuestionSettingsSingleChoice = openapi.NewQuestion{
+			Title:      "質問（単一選択）",
+			IsRequired: true,
+		}
+		err = sampleQuestionSettingsSingleChoice.FromQuestionSettingsSingleChoice(openapi.QuestionSettingsSingleChoice{
+			Options:      []string{"選択肢A", "選択肢B", "選択肢C", "選択肢D"},
+			QuestionType: openapi.QuestionSettingsSingleChoiceQuestionTypeSingleChoice,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQuestionSettingsSingleChoice: %v", err))
+		}
+		sampleQuestionSettingsMultipleChoice = openapi.NewQuestion{
+			Title:      "質問（複数選択）",
+			IsRequired: true,
+		}
+		err = sampleQuestionSettingsMultipleChoice.FromQuestionSettingsMultipleChoice(openapi.QuestionSettingsMultipleChoice{
+			Options:      []string{"選択肢A", "選択肢B", "選択肢C", "選択肢D"},
+			QuestionType: openapi.QuestionSettingsMultipleChoiceQuestionTypeMultipleChoice,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQuestionSettingsMultipleChoice: %v", err))
+		}
+		sampleQeustionsettingsScale = openapi.NewQuestion{
+			Title:      "質問（スケール）",
+			IsRequired: true,
+		}
+		sampleQeustionsettingsScaleMaxLabel := "最大値"
+		sampleQeustionsettingsScaleMinLabel := "最小値"
+		err = sampleQeustionsettingsScale.FromQuestionSettingsScale(openapi.QuestionSettingsScale{
+			MaxLabel:     &sampleQeustionsettingsScaleMaxLabel,
+			MaxValue:     10,
+			MinLabel:     &sampleQeustionsettingsScaleMinLabel,
+			MinValue:     1,
+			QuestionType: openapi.QuestionSettingsScaleQuestionTypeScale,
+		})
+		if err != nil {
+			panic(fmt.Sprintf("failed to setup sampleQeustionsettingsScale: %v", err))
+		}
 
-	sampleAdmin = openapi.UsersAndGroups{
-		Users:  []string{userOne},
-		Groups: []uuid.UUID{},
-	}
+		sampleAdmin = openapi.UsersAndGroups{
+			Users:  []string{userOne},
+			Groups: []uuid.UUID{},
+		}
 
-	sampleTarget = openapi.UsersAndGroups{
-		Users:  []string{userThree},
-		Groups: []uuid.UUID{},
-	}
+		sampleTarget = openapi.UsersAndGroups{
+			Users:  []string{userThree},
+			Groups: []uuid.UUID{},
+		}
 
-	sampleQuestionnaire = openapi.PostQuestionnaireJSONRequestBody{
-		Admin:                    sampleAdmin,
-		Description:              "第1回集会らん☆ぷろ参加者募集",
-		IsDuplicateAnswerAllowed: true,
-		IsAnonymous:              false,
-		IsPublished:              true,
-		Questions: []openapi.NewQuestion{
-			sampleQuestionSettingsText,
-			sampleQuestionSettingsTextLong,
-			sampleQuestionSettingsNumber,
-			sampleQuestionSettingsSingleChoice,
-			sampleQuestionSettingsMultipleChoice,
-			sampleQeustionsettingsScale,
-		},
-		ResponseDueDateTime: nil,
-		ResponseViewableBy:  "anyone",
-		Target:              sampleTarget,
-		Title:               "第1回集会らん☆ぷろ募集アンケート",
-	}
+		sampleQuestionnaire = openapi.PostQuestionnaireJSONRequestBody{
+			Admin:                    sampleAdmin,
+			Description:              "第1回集会らん☆ぷろ参加者募集",
+			IsDuplicateAnswerAllowed: true,
+			IsAnonymous:              false,
+			IsPublished:              true,
+			Questions: []openapi.NewQuestion{
+				sampleQuestionSettingsText,
+				sampleQuestionSettingsTextLong,
+				sampleQuestionSettingsNumber,
+				sampleQuestionSettingsSingleChoice,
+				sampleQuestionSettingsMultipleChoice,
+				sampleQeustionsettingsScale,
+			},
+			ResponseDueDateTime: nil,
+			ResponseViewableBy:  "anyone",
+			Target:              sampleTarget,
+			Title:               "第1回集会らん☆ぷろ募集アンケート",
+		}
+	})
 }
 
 func newSampleQuestionnaire() openapi.PostQuestionnaireJSONRequestBody {
@@ -2460,9 +2461,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 				responseIDList: &[]int{
 					response00.ResponseId,
 					response01.ResponseId,
-					response02.ResponseId,
 					responseUserTwo.ResponseId,
-					response03.ResponseId,
 				},
 			},
 		},
@@ -2595,6 +2594,21 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 			},
 			expect: expect{
 				isErr: true,
+			},
+		},
+		{
+			description: "non administrator default response list excludes draft responses",
+			args: args{
+				userID:          userTwo,
+				questionnaireID: questionnaireDetail.QuestionnaireId,
+				params:          openapi.GetQuestionnaireResponsesParams{},
+			},
+			expect: expect{
+				responseIDList: &[]int{
+					response00.ResponseId,
+					response01.ResponseId,
+					responseUserTwo.ResponseId,
+				},
 			},
 		},
 		{

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -163,6 +163,23 @@ func setupSampleQuestionnaire() {
 	}
 }
 
+func newSampleQuestionnaire() openapi.PostQuestionnaireJSONRequestBody {
+	setupSampleQuestionnaire()
+
+	// Deep-copy test fixtures so parallel tests do not share slice-backed state.
+	b, err := json.Marshal(sampleQuestionnaire)
+	if err != nil {
+		panic(fmt.Sprintf("failed to marshal sampleQuestionnaire: %v", err))
+	}
+
+	var questionnaire openapi.PostQuestionnaireJSONRequestBody
+	if err := json.Unmarshal(b, &questionnaire); err != nil {
+		panic(fmt.Sprintf("failed to unmarshal sampleQuestionnaire: %v", err))
+	}
+
+	return questionnaire
+}
+
 func newQuestion2Question(questionID *int, createdAt *time.Time, newQuestion openapi.NewQuestion) (openapi.Question, error) {
 	b, err := newQuestion.MarshalJSON()
 	if err != nil {
@@ -215,8 +232,9 @@ func TestGetQuestionnaires(t *testing.T) {
 
 	uniqueSearchTitle := fmt.Sprintf("search test %d", time.Now().UnixNano())
 	specialTargetUser := fmt.Sprintf("stgq%d", time.Now().UnixNano())
+	draftAdminUser := fmt.Sprintf("draft-admin-%d", time.Now().UnixNano())
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -227,7 +245,7 @@ func TestGetQuestionnaires(t *testing.T) {
 	_, err = q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.Title = uniqueSearchTitle
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
@@ -239,7 +257,7 @@ func TestGetQuestionnaires(t *testing.T) {
 	questionnairePosted1, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.Title = uniqueSearchTitle
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
@@ -251,7 +269,7 @@ func TestGetQuestionnaires(t *testing.T) {
 	questionnairePosted2, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.Title = "abcde"
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
@@ -263,7 +281,7 @@ func TestGetQuestionnaires(t *testing.T) {
 	_, err = q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.Target.Users = []string{specialTargetUser}
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
@@ -275,9 +293,10 @@ func TestGetQuestionnaires(t *testing.T) {
 	questionnairePosted4, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.Title = "draft questionnaire"
 	questionnaire.IsPublished = false
+	questionnaire.Admin.Users = []string{draftAdminUser}
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -293,11 +312,12 @@ func TestGetQuestionnaires(t *testing.T) {
 		params openapi.GetQuestionnairesParams
 	}
 	type expect struct {
-		isErr               bool
-		err                 error
-		questionnaireIDList *[]int
-		totalRecords        *int
-		pageMax             *int
+		isErr                   bool
+		err                     error
+		questionnaireIDList     *[]int
+		questionnaireIDContains *[]int
+		totalRecords            *int
+		pageMax                 *int
 	}
 	type test struct {
 		description string
@@ -523,11 +543,11 @@ func TestGetQuestionnaires(t *testing.T) {
 		{
 			description: "default list includes my draft questionnaire",
 			args: args{
-				userID: userOne,
+				userID: draftAdminUser,
 				params: openapi.GetQuestionnairesParams{},
 			},
 			expect: expect{
-				questionnaireIDList: &[]int{
+				questionnaireIDContains: &[]int{
 					questionnaireDraftByUserOne.QuestionnaireId,
 				},
 			},
@@ -535,7 +555,7 @@ func TestGetQuestionnaires(t *testing.T) {
 		{
 			description: "only administrated by me includes my draft questionnaire",
 			args: args{
-				userID: userOne,
+				userID: draftAdminUser,
 				params: openapi.GetQuestionnairesParams{
 					OnlyAdministratedByMe: &constTrue,
 				},
@@ -653,6 +673,15 @@ func TestGetQuestionnaires(t *testing.T) {
 			sort.Slice(questionnaireIDList, func(i, j int) bool { return questionnaireIDList[i] < questionnaireIDList[j] })
 			assertion.Equal(*testCase.expect.questionnaireIDList, questionnaireIDList, testCase.description, "questionnaireIDList")
 		}
+		if testCase.expect.questionnaireIDContains != nil {
+			questionnaireIDList := []int{}
+			for _, questionnairSummary := range questionnaireList.Questionnaires {
+				questionnaireIDList = append(questionnaireIDList, questionnairSummary.QuestionnaireId)
+			}
+			for _, questionnaireID := range *testCase.expect.questionnaireIDContains {
+				assertion.Contains(questionnaireIDList, questionnaireID, testCase.description, "questionnaireIDContains")
+			}
+		}
 		if testCase.expect.totalRecords != nil {
 			assertion.Equal(*testCase.expect.totalRecords, questionnaireList.TotalRecords, testCase.description, "totalRecords")
 		}
@@ -741,7 +770,7 @@ func TestPostQuestionnaire(t *testing.T) {
 		{
 			description: "valid",
 			args: args{
-				params: sampleQuestionnaire,
+				params: newSampleQuestionnaire(),
 			},
 		},
 		{
@@ -1241,7 +1270,7 @@ func TestGetQuestionnaire(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -1387,21 +1416,21 @@ func TestEditQuestionnaire(t *testing.T) {
 		{
 			description: "valid",
 			args: args{
-				params:        sampleQuestionnaire,
+				params:        newSampleQuestionnaire(),
 				isNewQuestion: []bool{false, false, false, false, false, false},
 			},
 		},
 		{
 			description: "valid new question",
 			args: args{
-				params:        sampleQuestionnaire,
+				params:        newSampleQuestionnaire(),
 				isNewQuestion: []bool{true, true, true, true, true, true},
 			},
 		},
 		{
 			description: "valid some new question",
 			args: args{
-				params:        sampleQuestionnaire,
+				params:        newSampleQuestionnaire(),
 				isNewQuestion: []bool{true, false, true, false, true, false},
 			},
 		},
@@ -1454,7 +1483,7 @@ func TestEditQuestionnaire(t *testing.T) {
 			description: "invalid question id",
 			args: args{
 				invalidQuestionID: true,
-				params:            sampleQuestionnaire,
+				params:            newSampleQuestionnaire(),
 				isNewQuestion:     []bool{false, false, false, false, false, false},
 			},
 			expect: expect{
@@ -1465,7 +1494,7 @@ func TestEditQuestionnaire(t *testing.T) {
 			description: "invalid anonymous to not anonymous",
 			args: args{
 				isAnonymousToNotAnonymous: true,
-				params:                    sampleQuestionnaire,
+				params:                    newSampleQuestionnaire(),
 				isNewQuestion:             []bool{false, false, false, false, false, false},
 			},
 			expect: expect{
@@ -1838,7 +1867,7 @@ func TestEditQuestionnaire(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaire := sampleQuestionnaire
+		questionnaire := newSampleQuestionnaire()
 		if testCase.args.isAnonymousToNotAnonymous {
 			questionnaire.IsAnonymous = true
 		}
@@ -2018,7 +2047,7 @@ func TestDeleteQuestionnaire(t *testing.T) {
 	for _, testCase := range testCases {
 		var questionnaireID int
 		if !testCase.args.invalidQuestionnaireID {
-			questionnaire := sampleQuestionnaire
+			questionnaire := newSampleQuestionnaire()
 			e := echo.New()
 			body, err := json.Marshal(questionnaire)
 			require.NoError(t, err)
@@ -2076,7 +2105,7 @@ func TestDeleteQuestionnaireWithResponses(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -2114,7 +2143,7 @@ func TestDeleteQuestionnaireWithEmptyDraft(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -2151,7 +2180,7 @@ func TestGetQuestionnaireMyRemindStatus(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -2197,7 +2226,7 @@ func TestEditQuestionnaireMyRemindStatus(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -2231,7 +2260,7 @@ func TestEditQuestionnaireMyRemindStatusPersistsExplicitSubscriptionAfterTargetR
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	questionnaire.Target = openapi.UsersAndGroups{
 		Users:  []string{userThree, userFour},
 		Groups: []uuid.UUID{},
@@ -2282,7 +2311,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -2354,7 +2383,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 	response03, err := q.PostQuestionnaireResponse(ctx, questionnaireDetail.QuestionnaireId, newResponse, userTwo)
 	require.NoError(t, err)
 
-	questionnaireAnonymous := sampleQuestionnaire
+	questionnaireAnonymous := newSampleQuestionnaire()
 	questionnaireAnonymous.IsAnonymous = true
 	e = echo.New()
 	body, err = json.Marshal(questionnaireAnonymous)
@@ -2723,7 +2752,7 @@ func TestPostQuestionnaireResponse(t *testing.T) {
 
 	responseDueDateTimePlus := time.Now().Add(24 * time.Hour)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	questionnaire.ResponseDueDateTime = &responseDueDateTimePlus
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
@@ -2735,7 +2764,7 @@ func TestPostQuestionnaireResponse(t *testing.T) {
 	questionnaireDetail, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.ResponseDueDateTime = &responseDueDateTimePlus
 	questionnaire.IsAnonymous = true
 	e = echo.New()
@@ -2748,7 +2777,7 @@ func TestPostQuestionnaireResponse(t *testing.T) {
 	questionnaireDetailAnonymous, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.ResponseDueDateTime = &responseDueDateTimePlus
 	questionnaire.IsDuplicateAnswerAllowed = false
 	e = echo.New()
@@ -2761,7 +2790,7 @@ func TestPostQuestionnaireResponse(t *testing.T) {
 	questionnaireDetailNoMultipleResponse, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
 	require.NoError(t, err)

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -275,6 +275,19 @@ func TestGetQuestionnaires(t *testing.T) {
 	questionnairePosted4, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
+	questionnaire = sampleQuestionnaire
+	questionnaire.Title = "draft questionnaire"
+	questionnaire.IsPublished = false
+	e = echo.New()
+	body, err = json.Marshal(questionnaire)
+	require.NoError(t, err)
+	req = httptest.NewRequest(http.MethodPost, "/questionnaires", bytes.NewReader(body))
+	rec = httptest.NewRecorder()
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	ctx = e.NewContext(req, rec)
+	questionnaireDraftByUserOne, err := q.PostQuestionnaire(ctx, questionnaire)
+	require.NoError(t, err)
+
 	type args struct {
 		userID string
 		params openapi.GetQuestionnairesParams
@@ -504,6 +517,32 @@ func TestGetQuestionnaires(t *testing.T) {
 				userID: userFive,
 				params: openapi.GetQuestionnairesParams{
 					OnlyAdministratedByMe: &constTrue,
+				},
+			},
+		},
+		{
+			description: "default list includes my draft questionnaire",
+			args: args{
+				userID: userOne,
+				params: openapi.GetQuestionnairesParams{},
+			},
+			expect: expect{
+				questionnaireIDList: &[]int{
+					questionnaireDraftByUserOne.QuestionnaireId,
+				},
+			},
+		},
+		{
+			description: "only administrated by me includes my draft questionnaire",
+			args: args{
+				userID: userOne,
+				params: openapi.GetQuestionnairesParams{
+					OnlyAdministratedByMe: &constTrue,
+				},
+			},
+			expect: expect{
+				questionnaireIDList: &[]int{
+					questionnaireDraftByUserOne.QuestionnaireId,
 				},
 			},
 		},
@@ -2502,7 +2541,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 			},
 		},
 		{
-			description: "isDraft true does not force only my response",
+			description: "administrator can view draft responses",
 			args: args{
 				userID:          userOne,
 				questionnaireID: questionnaireDetail.QuestionnaireId,
@@ -2514,6 +2553,36 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 			expect: expect{
 				responseIDList: &[]int{
 					response02.ResponseId,
+					response03.ResponseId,
+				},
+			},
+		},
+		{
+			description: "non administrator cannot view other respondents draft responses",
+			args: args{
+				userID:          userTwo,
+				questionnaireID: questionnaireDetail.QuestionnaireId,
+				params: openapi.GetQuestionnaireResponsesParams{
+					OnlyMyResponse: &constFalse,
+					IsDraft:        &constTrue,
+				},
+			},
+			expect: expect{
+				isErr: true,
+			},
+		},
+		{
+			description: "non administrator can still view only my draft responses",
+			args: args{
+				userID:          userTwo,
+				questionnaireID: questionnaireDetail.QuestionnaireId,
+				params: openapi.GetQuestionnaireResponsesParams{
+					OnlyMyResponse: &constTrue,
+					IsDraft:        &constTrue,
+				},
+			},
+			expect: expect{
+				responseIDList: &[]int{
 					response03.ResponseId,
 				},
 			},

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -2570,7 +2570,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 			},
 		},
 		{
-			description: "administrator can view draft responses",
+			description: "administrator cannot view other respondents draft responses",
 			args: args{
 				userID:          userOne,
 				questionnaireID: questionnaireDetail.QuestionnaireId,
@@ -2580,10 +2580,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 				},
 			},
 			expect: expect{
-				responseIDList: &[]int{
-					response02.ResponseId,
-					response03.ResponseId,
-				},
+				isErr: true,
 			},
 		},
 		{

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -2569,7 +2569,7 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 			},
 		},
 		{
-			description: "administrator cannot view other respondents draft responses",
+			description: "administrator draft response list returns only my draft responses",
 			args: args{
 				userID:          userOne,
 				questionnaireID: questionnaireDetail.QuestionnaireId,
@@ -2579,11 +2579,13 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 				},
 			},
 			expect: expect{
-				isErr: true,
+				responseIDList: &[]int{
+					response02.ResponseId,
+				},
 			},
 		},
 		{
-			description: "non administrator cannot view other respondents draft responses",
+			description: "non administrator draft response list returns only my draft responses",
 			args: args{
 				userID:          userTwo,
 				questionnaireID: questionnaireDetail.QuestionnaireId,
@@ -2593,7 +2595,9 @@ func TestGetQuestionnaireResponses(t *testing.T) {
 				},
 			},
 			expect: expect{
-				isErr: true,
+				responseIDList: &[]int{
+					response03.ResponseId,
+				},
 			},
 		},
 		{

--- a/controller/response_test.go
+++ b/controller/response_test.go
@@ -125,7 +125,7 @@ func TestGetMyResponses(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -196,7 +196,7 @@ func TestGetMyResponses(t *testing.T) {
 	response4, err := q.PostQuestionnaireResponse(ctx, questionnaireDetail.QuestionnaireId, newResponse, "myResponsesSpecialUser")
 	require.NoError(t, err)
 
-	questionnaireAnonymous := sampleQuestionnaire
+	questionnaireAnonymous := newSampleQuestionnaire()
 	questionnaireAnonymous.IsAnonymous = true
 	e = echo.New()
 	body, err = json.Marshal(questionnaireAnonymous)
@@ -425,7 +425,7 @@ func TestGetResponse(t *testing.T) {
 
 	assertion := assert.New(t)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
 	require.NoError(t, err)
@@ -451,7 +451,7 @@ func TestGetResponse(t *testing.T) {
 	response0, err := q.PostQuestionnaireResponse(ctx, questionnaireDetail.QuestionnaireId, newResponse, userOne)
 	require.NoError(t, err)
 
-	questionnaireAnonymous := sampleQuestionnaire
+	questionnaireAnonymous := newSampleQuestionnaire()
 	questionnaireAnonymous.IsAnonymous = true
 	e = echo.New()
 	body, err = json.Marshal(questionnaireAnonymous)
@@ -627,7 +627,7 @@ func TestDeleteResponse(t *testing.T) {
 	}
 
 	for _, testCase := range testCases {
-		questionnaire := sampleQuestionnaire
+		questionnaire := newSampleQuestionnaire()
 		e := echo.New()
 		body, err := json.Marshal(questionnaire)
 		require.NoError(t, err)
@@ -705,7 +705,7 @@ func TestEditResponse(t *testing.T) {
 
 	responseDueDateTimePlus := time.Now().Add(24 * time.Hour)
 
-	questionnaire := sampleQuestionnaire
+	questionnaire := newSampleQuestionnaire()
 	questionnaire.ResponseDueDateTime = &responseDueDateTimePlus
 	e := echo.New()
 	body, err := json.Marshal(questionnaire)
@@ -717,7 +717,7 @@ func TestEditResponse(t *testing.T) {
 	questionnaireDetail, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	questionnaire.ResponseDueDateTime = &responseDueDateTimePlus
 	questionnaire.IsAnonymous = true
 	e = echo.New()
@@ -730,7 +730,7 @@ func TestEditResponse(t *testing.T) {
 	questionnaireDetailAnonymous, err := q.PostQuestionnaire(ctx, questionnaire)
 	require.NoError(t, err)
 
-	questionnaire = sampleQuestionnaire
+	questionnaire = newSampleQuestionnaire()
 	e = echo.New()
 	body, err = json.Marshal(questionnaire)
 	require.NoError(t, err)


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

# リリースノート

* **バグ修正**
  * ドラフト回答の閲覧権限を厳格化しました。ユーザーが自身のものでないドラフト回答は閲覧できず、該当操作は権限エラー（403）になります。

* **テスト**
  * ドラフト表示とアクセス制御を網羅する追加・改良されたテストを導入し、テスト間の状態共有を排除して信頼性を向上しました。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->