### PR TITLE
fix: Notify traQ when questionnaires are published

### DIFF
--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -445,14 +445,16 @@ func (q *Questionnaire) PostQuestionnaire(c echo.Context, params openapi.PostQue
 			}
 		}
 
-		notificationMessages = createQuestionnaireMessage(
-			questionnaireID,
-			params.Title,
-			params.Description,
-			append(allAdminUsers, adminGroupNames...),
-			responseDueDateTime,
-			append(allTargetUsers, targetGroupNames...),
-		)
+		if params.IsPublished {
+			notificationMessages = createQuestionnaireMessage(
+				questionnaireID,
+				params.Title,
+				params.Description,
+				append(allAdminUsers, adminGroupNames...),
+				responseDueDateTime,
+				append(allTargetUsers, targetGroupNames...),
+			)
+		}
 
 		if params.ResponseDueDateTime != nil && params.IsPublished {
 			dueDateTime := responseDueDateTime.Time
@@ -505,6 +507,12 @@ func (q *Questionnaire) GetQuestionnaire(ctx echo.Context, questionnaireID int) 
 }
 
 func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, params openapi.EditQuestionnaireJSONRequestBody) error {
+	questionnaireBeforeEdit, targetsBeforeEdit, _, targetGroupsBeforeEdit, adminsBeforeEdit, _, adminGroupsBeforeEdit, _, err := q.GetQuestionnaireInfo(c.Request().Context(), questionnaireID)
+	if err != nil {
+		c.Logger().Errorf("failed to get questionnaire info before edit: %+v", err)
+		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get questionnaire info before edit")
+	}
+
 	// unable to change the questionnaire from anonymous to non-anonymous
 	isAnonymous, err := q.GetResponseIsAnonymousByQuestionnaireID(c.Request().Context(), questionnaireID)
 	if err != nil {
@@ -531,8 +539,14 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 		return echo.NewHTTPError(http.StatusBadRequest, "invalid title")
 	}
 
+	var notificationMessages []string
 	err = q.ITransaction.Do(c.Request().Context(), nil, func(ctx context.Context) error {
-		err := q.UpdateQuestionnaire(ctx, params.Title, params.Description, responseDueDateTime, convertResponseViewableBy(params.ResponseViewableBy), questionnaireID, params.IsPublished, params.IsAnonymous, params.IsDuplicateAnswerAllowed)
+		allTargetUsers := targetsBeforeEdit
+		targetGroupIDs := targetGroupsBeforeEdit
+		allAdminUsers := adminsBeforeEdit
+		adminGroupIDs := adminGroupsBeforeEdit
+
+		err = q.UpdateQuestionnaire(ctx, params.Title, params.Description, responseDueDateTime, convertResponseViewableBy(params.ResponseViewableBy), questionnaireID, params.IsPublished, params.IsAnonymous, params.IsDuplicateAnswerAllowed)
 		if err != nil && !errors.Is(err, model.ErrNoRecordUpdated) {
 			c.Logger().Errorf("failed to update questionnaire: %+v", err)
 			return err
@@ -553,11 +567,12 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 				c.Logger().Errorf("failed to delete target groups: %+v", err)
 				return err
 			}
-			allTargetUsers, err := rollOutUsersAndGroups((*params.Target).Users, params.Target.Groups)
+			allTargetUsers, err = rollOutUsersAndGroups((*params.Target).Users, params.Target.Groups)
 			if err != nil {
 				c.Logger().Errorf("failed to roll out users and groups: %+v", err)
 				return err
 			}
+			targetGroupIDs = params.Target.Groups
 			err = q.InsertTargets(ctx, questionnaireID, allTargetUsers)
 			if err != nil {
 				c.Logger().Errorf("failed to insert targets: %+v", err)
@@ -590,7 +605,7 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 				c.Logger().Errorf("failed to delete administrator groups: %+v", err)
 				return err
 			}
-			allAdminUsers, err := rollOutUsersAndGroups(params.Admin.Users, params.Admin.Groups)
+			allAdminUsers, err = rollOutUsersAndGroups(params.Admin.Users, params.Admin.Groups)
 			if err != nil {
 				c.Logger().Errorf("failed to roll out administrators: %+v", err)
 				return err
@@ -599,6 +614,7 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 				c.Logger().Errorf("no administrators")
 				return errors.New("no administrators")
 			}
+			adminGroupIDs = params.Admin.Groups
 			err = q.InsertAdministrators(ctx, questionnaireID, allAdminUsers)
 			if err != nil {
 				c.Logger().Errorf("failed to insert administrators: %+v", err)
@@ -915,11 +931,38 @@ func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, p
 			}
 		}
 
+		if !questionnaireBeforeEdit.IsPublished && params.IsPublished {
+			targetGroupNames, err := uuid2GroupNames(targetGroupIDs)
+			if err != nil {
+				c.Logger().Errorf("failed to get target group names: %+v", err)
+				return err
+			}
+			adminGroupNames, err := uuid2GroupNames(adminGroupIDs)
+			if err != nil {
+				c.Logger().Errorf("failed to get admin group names: %+v", err)
+				return err
+			}
+			notificationMessages = createQuestionnaireMessage(
+				questionnaireID,
+				params.Title,
+				params.Description,
+				append(allAdminUsers, adminGroupNames...),
+				responseDueDateTime,
+				append(allTargetUsers, targetGroupNames...),
+			)
+		}
+
 		return nil
 	})
 	if err != nil {
 		c.Logger().Errorf("failed to update a questionnaire: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to update a questionnaire")
+	}
+
+	for _, message := range notificationMessages {
+		if err := q.PostMessage(message); err != nil {
+			c.Logger().Errorf("failed to post questionnaire publication message (questionnaireID: %d): %+v", questionnaireID, err)
+		}
 	}
 
 	return nil

--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -509,6 +509,9 @@ func (q *Questionnaire) GetQuestionnaire(ctx echo.Context, questionnaireID int) 
 func (q *Questionnaire) EditQuestionnaire(c echo.Context, questionnaireID int, params openapi.EditQuestionnaireJSONRequestBody) error {
 	questionnaireBeforeEdit, targetsBeforeEdit, _, targetGroupsBeforeEdit, adminsBeforeEdit, _, adminGroupsBeforeEdit, _, err := q.GetQuestionnaireInfo(c.Request().Context(), questionnaireID)
 	if err != nil {
+		if errors.Is(err, model.ErrRecordNotFound) {
+			return echo.NewHTTPError(http.StatusNotFound, "questionnaire not found")
+		}
 		c.Logger().Errorf("failed to get questionnaire info before edit: %+v", err)
 		return echo.NewHTTPError(http.StatusInternalServerError, "failed to get questionnaire info before edit")
 	}

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -51,6 +51,20 @@ var (
 	sampleQuestionnaire                  = openapi.PostQuestionnaireJSONRequestBody{}
 )
 
+type recordingWebhook struct {
+	messages []string
+}
+
+func (w *recordingWebhook) PostMessage(message string) error {
+	w.messages = append(w.messages, message)
+	return nil
+}
+
+func newTestQuestionnaireWithWebhook(webhook *recordingWebhook) *Questionnaire {
+	response := NewResponse(IQuestionnaire, IRespondent, IResponse, ITarget, IQuestion, IOption, IValidation, IScaleLabel, ITransaction)
+	return NewQuestionnaire(IQuestionnaire, ITarget, ITargetGroup, ITargetUser, IAdministrator, IAdministratorGroup, IAdministratorUser, IQuestion, IOption, IScaleLabel, IValidation, ITransaction, IRespondent, webhook, response, NewReminder())
+}
+
 func setupSampleQuestionnaire() {
 	if sampleQuestionnaire.Title != "" {
 		return
@@ -1188,6 +1202,106 @@ func TestPostQuestionnaire(t *testing.T) {
 			assertion.Equal(*testCase.expect.hasReminder, remindStatus, testCase.description, "reminder status")
 		}
 	}
+}
+
+func TestQuestionnairePublicationNotification(t *testing.T) {
+	assertion := assert.New(t)
+
+	post := func(t *testing.T, questionnaireController *Questionnaire, params openapi.PostQuestionnaireJSONRequestBody) openapi.QuestionnaireDetail {
+		t.Helper()
+
+		e := echo.New()
+		body, err := json.Marshal(params)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPost, "/questionnaires", bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		ctx := e.NewContext(req, rec)
+		detail, err := questionnaireController.PostQuestionnaire(ctx, params)
+		require.NoError(t, err)
+		return detail
+	}
+
+	edit := func(t *testing.T, questionnaireController *Questionnaire, detail openapi.QuestionnaireDetail, params openapi.PostQuestionnaireJSONRequestBody) {
+		t.Helper()
+
+		editParams := postQuestionnaireParams2EditQuestionnaireParams(detail.QuestionnaireId, detail.Questions, params)
+		e := echo.New()
+		body, err := json.Marshal(editParams)
+		require.NoError(t, err)
+		req := httptest.NewRequest(http.MethodPatch, fmt.Sprintf("/questionnaires/%d", detail.QuestionnaireId), bytes.NewReader(body))
+		rec := httptest.NewRecorder()
+		req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+		ctx := e.NewContext(req, rec)
+		err = questionnaireController.EditQuestionnaire(ctx, detail.QuestionnaireId, editParams)
+		require.NoError(t, err)
+	}
+
+	t.Run("not published on create does not notify", func(t *testing.T) {
+		webhook := &recordingWebhook{}
+		questionnaireController := newTestQuestionnaireWithWebhook(webhook)
+		params := sampleQuestionnaire
+		params.IsPublished = false
+
+		post(t, questionnaireController, params)
+
+		assertion.Len(webhook.messages, 0)
+	})
+
+	t.Run("published on create notifies", func(t *testing.T) {
+		webhook := &recordingWebhook{}
+		questionnaireController := newTestQuestionnaireWithWebhook(webhook)
+		params := sampleQuestionnaire
+		params.IsPublished = true
+
+		post(t, questionnaireController, params)
+
+		assertion.Len(webhook.messages, 1)
+	})
+
+	t.Run("draft to published notifies", func(t *testing.T) {
+		webhook := &recordingWebhook{}
+		questionnaireController := newTestQuestionnaireWithWebhook(webhook)
+		params := sampleQuestionnaire
+		params.IsPublished = false
+		detail := post(t, questionnaireController, params)
+
+		params.IsPublished = true
+		edit(t, questionnaireController, detail, params)
+
+		assertion.Len(webhook.messages, 1)
+	})
+
+	t.Run("published to published edit does not notify", func(t *testing.T) {
+		webhook := &recordingWebhook{}
+		questionnaireController := newTestQuestionnaireWithWebhook(webhook)
+		params := sampleQuestionnaire
+		params.IsPublished = true
+		detail := post(t, questionnaireController, params)
+		webhook.messages = nil
+
+		params.Description = "公開状態のまま編集"
+		edit(t, questionnaireController, detail, params)
+
+		assertion.Len(webhook.messages, 0)
+	})
+
+	t.Run("republish notifies each time", func(t *testing.T) {
+		webhook := &recordingWebhook{}
+		questionnaireController := newTestQuestionnaireWithWebhook(webhook)
+		params := sampleQuestionnaire
+		params.IsPublished = false
+		detail := post(t, questionnaireController, params)
+
+		params.IsPublished = true
+		edit(t, questionnaireController, detail, params)
+		params.IsPublished = false
+		edit(t, questionnaireController, detail, params)
+		params.IsPublished = true
+		edit(t, questionnaireController, detail, params)
+
+		assertion.Len(webhook.messages, 2)
+	})
 }
 
 func TestGetQuestionnaire(t *testing.T) {


### PR DESCRIPTION
一回下書きに戻してから再度公開した場合も通知が飛ぶようにしている

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## リリースノート

* **改善**
  * アンケートの通知挙動を改善しました：下書きでは通知を送らず、公開に遷移したときのみ通知が送信されます。編集で公開に切り替えた場合も正しく通知され、既に公開済みの編集では通知されません。
* **テスト**
  * 公開／非公開の遷移に伴う通知動作を検証する自動テストを追加しました（通知の発生回数を確認）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->