### PR TITLE
fix: for GET /questionnaires, exclude non-draft questionnaires when not explicitly fetching drafts and onlyAdministratedByMe is false

### DIFF
--- a/controller/questionnaire.go
+++ b/controller/questionnaire.go
@@ -144,6 +144,13 @@ func (q *Questionnaire) GetQuestionnaires(ctx echo.Context, userID string, param
 	if isDraft != nil && *isDraft {
 		onlyAdministratedByMe = true
 	}
+
+	if !onlyAdministratedByMe && isDraft == nil {
+		// When not specifically fetching drafts and onlyAdministratedByMe is false, exclude them from the list
+		v := false
+		isDraft = &v
+	}
+
 	countOnly := params.CountOnly != nil && *params.CountOnly
 
 	questionnaireList, totalRecords, pageMax, err := q.IQuestionnaire.GetQuestionnaires(ctx.Request().Context(), userID, sort, search, pageNum, onlyTargetingMe, onlyAdministratedByMe, notOverDue, hasMyResponse, hasMyDraft, isDraft, countOnly)

--- a/controller/questionnaire_test.go
+++ b/controller/questionnaire_test.go
@@ -331,6 +331,7 @@ func TestGetQuestionnaires(t *testing.T) {
 		err                     error
 		questionnaireIDList     *[]int
 		questionnaireIDContains *[]int
+		questionnaireIDExcludes *[]int
 		totalRecords            *int
 		pageMax                 *int
 	}
@@ -556,13 +557,13 @@ func TestGetQuestionnaires(t *testing.T) {
 			},
 		},
 		{
-			description: "default list includes my draft questionnaire",
+			description: "default list excludes my draft questionnaire",
 			args: args{
 				userID: draftAdminUser,
 				params: openapi.GetQuestionnairesParams{},
 			},
 			expect: expect{
-				questionnaireIDContains: &[]int{
+				questionnaireIDExcludes: &[]int{
 					questionnaireDraftByUserOne.QuestionnaireId,
 				},
 			},
@@ -695,6 +696,15 @@ func TestGetQuestionnaires(t *testing.T) {
 			}
 			for _, questionnaireID := range *testCase.expect.questionnaireIDContains {
 				assertion.Contains(questionnaireIDList, questionnaireID, testCase.description, "questionnaireIDContains")
+			}
+		}
+		if testCase.expect.questionnaireIDExcludes != nil {
+			questionnaireIDList := []int{}
+			for _, questionnairSummary := range questionnaireList.Questionnaires {
+				questionnaireIDList = append(questionnaireIDList, questionnairSummary.QuestionnaireId)
+			}
+			for _, questionnaireID := range *testCase.expect.questionnaireIDExcludes {
+				assertion.NotContains(questionnaireIDList, questionnaireID, testCase.description, "questionnaireIDExcludes")
 			}
 		}
 		if testCase.expect.totalRecords != nil {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * 条件によりドラフト（未発行）のアンケートがデフォルトで検索結果から除外されるようになりました。
* **テスト**
  * 検索結果の除外挙動を検証するテストを追加・更新しました（特定のアンケートIDの除外確認を含む）。
<!-- end of auto-generated comment: release notes by coderabbit.ai -->