### PR TITLE
fix: normalize reminder 18:00 rounding to Asia/Tokyo

### DIFF
--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -6,9 +6,6 @@ import (
 	"sort"
 	"sync"
 	"time"
-	// Embed the timezone database so time.LoadLocation("Asia/Tokyo") works
-	// even on minimal runtime images without system zoneinfo.
-	_ "time/tzdata"
 
 	"github.com/google/btree"
 	"github.com/traPtitech/anke-to/model"

--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -6,6 +6,8 @@ import (
 	"sort"
 	"sync"
 	"time"
+	// Embed the timezone database so time.LoadLocation("Asia/Tokyo") works
+	// even on minimal runtime images without system zoneinfo.
 	_ "time/tzdata"
 
 	"github.com/google/btree"

--- a/controller/reminder.go
+++ b/controller/reminder.go
@@ -6,11 +6,20 @@ import (
 	"sort"
 	"sync"
 	"time"
+	_ "time/tzdata"
 
 	"github.com/google/btree"
 	"github.com/traPtitech/anke-to/model"
 	"github.com/traPtitech/anke-to/traq"
 )
+
+var jst = func() *time.Location {
+	loc, err := time.LoadLocation("Asia/Tokyo")
+	if err != nil {
+		panic(err)
+	}
+	return loc
+}()
 
 type Job struct {
 	Timestamp       time.Time
@@ -125,6 +134,7 @@ func (re *Reminder) PushReminder(questionnaireID int, limit *time.Time) error {
 }
 
 func reminderTimestamp(limit time.Time, timingMinutes int) time.Time {
+	limit = limit.In(jst)
 	remindTimeStamp := limit.Add(-time.Duration(timingMinutes) * time.Minute)
 	if timingMinutes < 24*60 {
 		return remindTimeStamp
@@ -138,7 +148,7 @@ func reminderTimestamp(limit time.Time, timingMinutes int) time.Time {
 		0,
 		0,
 		0,
-		remindTimeStamp.Location(),
+		jst,
 	)
 	if remindDateAt18.Before(remindTimeStamp) {
 		return remindDateAt18

--- a/controller/reminder_test.go
+++ b/controller/reminder_test.go
@@ -153,7 +153,8 @@ func TestPushReminder(t *testing.T) {
 func TestReminderTimestamp(t *testing.T) {
 	t.Parallel()
 
-	jst := time.FixedZone("JST", 9*60*60)
+	jst, err := time.LoadLocation("Asia/Tokyo")
+	require.NoError(t, err)
 
 	testCases := []struct {
 		description   string
@@ -178,6 +179,12 @@ func TestReminderTimestamp(t *testing.T) {
 			limit:         time.Date(2026, 5, 10, 23, 59, 0, 0, jst),
 			timingMinutes: 60,
 			expected:      time.Date(2026, 5, 10, 22, 59, 0, 0, jst),
+		},
+		{
+			description:   "limit in UTC is normalized to JST before 18:00 rounding",
+			limit:         time.Date(2026, 5, 10, 14, 59, 0, 0, time.UTC),
+			timingMinutes: 10080,
+			expected:      time.Date(2026, 5, 3, 18, 0, 0, 0, jst),
 		},
 	}
 

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	_ "net/http/pprof"
 	"os"
 	"strings"
+	_ "time/tzdata"
 
 	"github.com/labstack/echo/v4"
 	"github.com/labstack/echo/v4/middleware"

--- a/wire_gen.go
+++ b/wire_gen.go
@@ -16,6 +16,7 @@ import (
 
 import (
 	_ "net/http/pprof"
+	_ "time/tzdata"
 )
 
 // Injectors from wire.go:


### PR DESCRIPTION
reminderTimestamp built the daily-reminder 18:00 timestamp with the input limit's Location. When the questionnaire deadline arrived via the HTTP API with a UTC offset (e.g. a frontend sending an ISO string with "Z"), 18:00 UTC turned into 03:00 JST and reminders fired in the middle of the night. Convert limit to Asia/Tokyo at the entry of the function and use that Location to construct the 18:00 instant so the rounding is always JST regardless of the input's offset. Embed time/tzdata to keep LoadLocation working in minimal runtime environments.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **バグ修正**
  * リマインダーの時刻計算がJST（アジア/東京）で統一され、異なるタイムゾーンからの入力でも18:00基準で正しく算出されるようになりました。

* **テスト**
  * JST基準でのタイムゾーン変換を検証するテストケースを追加しました。

* **雑務**
  * アプリ起動時にタイムゾーンデータを組み込む初期化を追加しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/anke-to/pull/1556?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->