### PR TITLE
fix auto-generated CI rerun

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -6,6 +6,7 @@ on:
       - "main"
       - "develop"
   pull_request:
+  workflow_dispatch:
 
 env:
   TZ: Asia/Tokyo
@@ -15,7 +16,10 @@ jobs:
     name: Generate files
     runs-on: ubuntu-24.04
     permissions:
+      actions: write
       contents: write
+    outputs:
+      generated_commit: ${{ steps.auto_commit.outputs.committed }}
     concurrency:
       group: auto-generate-${{ github.head_ref || github.ref_name }}
       cancel-in-progress: true
@@ -30,6 +34,7 @@ jobs:
       - run: go generate ./openapi
       - run: go generate -run "wire" ./...
       - name: Auto-commit generated files
+        id: auto_commit
         if: github.event_name == 'pull_request' && github.actor != 'github-actions[bot]' && github.event.pull_request.head.repo.full_name == github.repository
         run: |
           git config user.name "github-actions[bot]"
@@ -37,9 +42,15 @@ jobs:
           files=(openapi/server.go openapi/spec.go openapi/types.go wire_gen.go)
           if ! git diff --quiet -- "${files[@]}"; then
             git add "${files[@]}"
-            git commit -m "chore: regenerate generated files [skip ci]"
+            git commit -m "chore: regenerate generated files"
             git push origin HEAD:${{ github.head_ref }}
+            gh workflow run main.yml --ref "${{ github.head_ref }}"
+            echo "committed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
+        env:
+          GH_TOKEN: ${{ github.token }}
       - name: Verify generated files are committed
         if: github.event_name != 'pull_request' || github.actor == 'github-actions[bot]' || github.event.pull_request.head.repo.full_name != github.repository
         run: |
@@ -53,6 +64,7 @@ jobs:
     name: Mod
     runs-on: ubuntu-24.04
     needs: [generate]
+    if: needs.generate.outputs.generated_commit != 'true'
     steps:
       - uses: actions/checkout@v4
         with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,14 +43,15 @@ jobs:
           if ! git diff --quiet -- "${files[@]}"; then
             git add "${files[@]}"
             git commit -m "chore: regenerate generated files"
-            git push origin HEAD:${{ github.head_ref }}
-            gh workflow run main.yml --ref "${{ github.head_ref }}"
+            git push origin "HEAD:${HEAD_REF}"
+            gh workflow run main.yml --ref "${HEAD_REF}"
             echo "committed=true" >> "$GITHUB_OUTPUT"
           else
             echo "committed=false" >> "$GITHUB_OUTPUT"
           fi
         env:
           GH_TOKEN: ${{ github.token }}
+          HEAD_REF: ${{ github.head_ref }}
       - name: Verify generated files are committed
         if: github.event_name != 'pull_request' || github.actor == 'github-actions[bot]' || github.event.pull_request.head.repo.full_name != github.repository
         run: |


### PR DESCRIPTION
## Summary

Fix the auto-generated file commit flow in CI so that the generated commit is followed by a full CI run.

## Background

The previous auto-commit used `[skip ci]`, so when GitHub Actions pushed regenerated files back to a PR branch, the follow-up commit did not run the full CI workflow. This could leave the PR without checks for the actual commit that would be merged.

## Changes

- Add `workflow_dispatch` to the CI workflow.
- Remove `[skip ci]` from the generated-files commit message.
- Dispatch the CI workflow after pushing an auto-generated commit.
- Add `actions: write` permission for the generate job so it can trigger the workflow dispatch.
- Skip downstream jobs in the original run when it has just pushed an auto-generated commit, letting the dispatched run check the updated branch state.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 改善

* **Improvements**
  * CI/CDワークフローの手動実行機能を追加しました。
  * 自動生成ファイルのコミット時に、不要な重複実行を抑止する処理を実装しました。

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/traPtitech/anke-to/pull/1561?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->