### PR TITLE
fix: fix reminder test flake

### DIFF
--- a/controller/reminder_test.go
+++ b/controller/reminder_test.go
@@ -85,7 +85,7 @@ func TestPushReminder(t *testing.T) {
 			description: "3 reminders",
 			args: args{
 				questionnaireID: 1,
-				time:            time.Now().Add(25 * time.Hour),
+				time:            time.Now().Add(23 * time.Hour),
 			},
 			expect: expect{
 				num: 3,


### PR DESCRIPTION
## Summary

Stabilize reminder tests that depend on the current time.

## Background

`TestPushReminder` uses deadlines relative to `time.Now()` and expects a fixed number of scheduled reminder jobs. One case used a deadline 25 hours in the future and expected 3 reminders.

However, reminders that are 1 day or more before the deadline are rounded to JST 18:00. When the test runs between JST 17:00 and 18:00, the `1日前` reminder can still be in the future after rounding, so the test schedules 4 reminders instead of 3.

## Changes

- Change the unstable 25-hour reminder test deadlines to 23 hours.
- Keep the test coverage focused on the intended “less than one day remaining” case, which should schedule only the 12-hour, 6-hour, and 1-hour reminders.