### PR TITLE
ci: gha-security のセキュリティチェックを導入（パイロット）

### DIFF
--- a/.github/workflows/security-checks.yaml
+++ b/.github/workflows/security-checks.yaml
@@ -1,0 +1,37 @@
+# 各リポジトリに配置する caller ワークフロー（PR 時のセキュリティチェック一式）。
+# .github/workflows/security-checks.yaml として配置する。
+name: security-checks
+
+on:
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  # 未固定の action / イメージ参照を検出し、修正を suggestion で提案する
+  pin-support:
+    permissions:
+      contents: read
+      pull-requests: write
+    uses: traPtitech/gha-security/.github/workflows/pin-support.yaml@main
+    with:
+      mode: suggest # commit にすると PR ブランチへ直接修正コミットを push する（要 contents: write）
+
+  # 未固定の参照があれば fail（導入直後は required check にせず様子見を推奨）
+  pin-check:
+    permissions:
+      contents: read
+    uses: traPtitech/gha-security/.github/workflows/pin-check.yaml@main
+
+  # 公開から日が浅い依存バージョンの混入を検出して fail
+  # 緊急時は PR に `cooldown-override` ラベルを付けるとスキップされる
+  # 不要な job はまるごと削除してよい（各機能は独立してオン/オフ可能）
+  cooldown-check:
+    permissions:
+      contents: read
+    uses: traPtitech/gha-security/.github/workflows/cooldown-check.yaml@main
+    # with:
+    #   npm-min-age-days: 0      # npm チェックを無効化する場合
+    #   go-min-age-days: 0       # Go チェックを無効化する場合
+    #   actions-min-age-days: 0  # actions チェックを無効化する場合

--- a/.github/workflows/security-checks.yaml
+++ b/.github/workflows/security-checks.yaml
@@ -24,14 +24,16 @@ jobs:
       contents: read
     uses: traPtitech/gha-security/.github/workflows/pin-check.yaml@main
 
-  # 公開から日が浅い依存バージョンの混入を検出して fail
+  # 公開から日が浅い依存バージョンの混入を検出して fail し、違反内容を PR コメントで通知
   # 緊急時は PR に `cooldown-override` ラベルを付けるとスキップされる
   # 不要な job はまるごと削除してよい（各機能は独立してオン/オフ可能）
   cooldown-check:
     permissions:
       contents: read
+      pull-requests: write # 違反の PR コメント投稿用（pr-comment: false なら read のみで可）
     uses: traPtitech/gha-security/.github/workflows/cooldown-check.yaml@main
     # with:
+    #   pr-comment: false        # PR コメント通知を無効化する場合
     #   npm-min-age-days: 0      # npm チェックを無効化する場合
     #   go-min-age-days: 0       # Go チェックを無効化する場合
     #   actions-min-age-days: 0  # actions チェックを無効化する場合


### PR DESCRIPTION
[traPtitech/gha-security](https://github.com/traPtitech/gha-security) のパイロット導入です（このリポジトリは「固定済みリポジトリで誤検知が出ないこと」の確認役）。

## 追加されるチェック（すべて `pull_request` 時）

| ジョブ | 内容 |
|---|---|
| **pin-support** | PR に未固定の `uses:` / イメージ参照があれば、修正を suggestion コメントで提案 |
| **pin-check** | 未固定参照があれば fail（`pinact --check --verify-comment`。SHA とバージョンコメントの不一致=コメント偽装も検出） |
| **cooldown-check** | PR で追加/変更された依存（gomod / npm / actions）に**公開から日が浅いバージョン**があれば fail。緊急時は `cooldown-override` ラベルでスキップ可 |

## このリポジトリへの影響

- anke-to は既に全 actions が SHA 固定・全イメージが digest 固定済みのため、**現状のままで全チェックがグリーンになる想定**です（ローカルで検証済み）
- Dependabot の更新 PR も cooldown-check の対象になります（公開3日未満の版への bump は赤くなります。Dependabot 側にも 2026-07 からデフォルト3日の cooldown が入っているため、通常は競合しません）
- 各機能は独立してオン/オフできます（ジョブ削除、`npm-min-age-days: 0` などの入力。詳細は [gha-security の README](https://github.com/traPtitech/gha-security#機能のオンオフ)）

問題なく運用できることが確認できたら、org の他リポジトリにも展開していく予定です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **新機能**
  * プルリクエスト時に、アクションやイメージの参照固定状況を自動確認するセキュリティチェックを追加しました。
  * 公開直後の依存バージョンの使用を検出し、必要に応じてチェック結果を失敗として通知します。
  * 参照固定に関する問題には、修正案を提示します。

<!-- end of auto-generated comment: release notes by coderabbit.ai -->